### PR TITLE
chore: align admin notification tests with live flows

### DIFF
--- a/app/admin/test/page.tsx
+++ b/app/admin/test/page.tsx
@@ -21,31 +21,118 @@ type ScenarioConfig = {
 };
 
 const CUSTOMER_SCENARIOS: ScenarioConfig[] = [
-  { key: "welcome_email", title: "Welcome Email", description: "Sends welcome email to test customer" },
-  { key: "appointment_confirmed", title: "Appointment Confirmed", description: "Confirmation email + admin notification + SMS" },
-  { key: "appointment_cancelled", title: "Appointment Cancelled", description: "Cancellation email + admin notification + SMS" },
-  { key: "appointment_rescheduled", title: "Appointment Rescheduled", description: "Reschedule email + admin notification + SMS" },
-  { key: "appointment_started", title: "Appointment Started", description: "In-progress email + admin notification + SMS" },
-  { key: "appointment_completed", title: "Appointment Completed", description: "Completion + review request emails + SMS" },
-  { key: "reminder", title: "24h Reminder", description: "Appointment reminder email to customer" },
+  {
+    key: "booking_received",
+    title: "Booking Received",
+    description:
+      "Customer booking-received email plus the paired admin booking alert.",
+  },
+  {
+    key: "appointment_confirmed",
+    title: "Appointment Confirmed",
+    description:
+      "Customer confirmation email plus the paired admin appointment update.",
+  },
+  {
+    key: "appointment_cancelled",
+    title: "Appointment Cancelled",
+    description:
+      "Customer cancellation email plus the paired admin appointment update.",
+  },
+  {
+    key: "appointment_rescheduled",
+    title: "Appointment Rescheduled",
+    description:
+      "Customer reschedule email plus the paired admin appointment update.",
+  },
+  {
+    key: "appointment_started",
+    title: "Appointment Started",
+    description:
+      "Customer in-progress email plus the paired admin appointment update.",
+  },
+  {
+    key: "appointment_completed",
+    title: "Appointment Completed",
+    description:
+      "Customer completion email, admin completion alert, and review-request follow-up.",
+  },
+  {
+    key: "review_request",
+    title: "Review Request",
+    description: "Standalone customer review-request email after completion.",
+  },
+  {
+    key: "reminder",
+    title: "24h Reminder",
+    description: "Customer reminder email for the day before service.",
+  },
+  {
+    key: "abandoned_checkout_recovery",
+    title: "Abandoned Checkout Recovery",
+    description:
+      "Customer recovery email for a saved booking draft that was never paid.",
+  },
 ];
 
 const ADMIN_SCENARIOS: ScenarioConfig[] = [
-  { key: "new_customer_onboarded", title: "New Customer Onboarded", description: "Admin email + SMS for new customer" },
-  { key: "deposit_paid", title: "Deposit Paid", description: "Admin notification for deposit payment" },
-  { key: "review_submitted", title: "Review Submitted", description: "Admin email + SMS for new review" },
-  { key: "mileage_log_required", title: "Mileage Log Required", description: "Admin email + SMS for pending mileage log" },
+  {
+    key: "deposit_paid",
+    title: "Deposit Paid",
+    description: "Admin finance alert for a successful booking deposit payment.",
+  },
+  {
+    key: "review_submitted",
+    title: "Review Submitted",
+    description: "Admin alert for a newly submitted customer review.",
+  },
+  {
+    key: "mileage_log_required",
+    title: "Mileage Log Required",
+    description: "Admin alert when a completed appointment needs a mileage log.",
+  },
+  {
+    key: "payment_failed",
+    title: "Payment Failed",
+    description:
+      "Admin alert for a failed invoice or subscription payment attempt.",
+  },
 ];
 
 const SUBSCRIPTION_SCENARIOS: ScenarioConfig[] = [
-  { key: "subscription_checkout_link", title: "Subscription Checkout Link", description: "Email sent to customer with Stripe checkout link for recurring service" },
-  { key: "subscription_appointment_created", title: "Subscription Appointment Created", description: "Email sent when auto-scheduled appointment is created" },
+  {
+    key: "subscription_checkout_link",
+    title: "Subscription Checkout Link",
+    description:
+      "Customer checkout-link email plus the paired admin notification.",
+  },
+  {
+    key: "subscription_appointment_created",
+    title: "Subscription Appointment Created",
+    description:
+      "Customer recurring appointment email plus the paired admin appointment alert.",
+  },
 ];
 
 const FLOW_SCENARIOS: ScenarioConfig[] = [
-  { key: "full_guest_checkout", title: "Full Flow: Guest Checkout", description: "New Customer -> Deposit Paid -> Confirmed -> Started -> Completed" },
-  { key: "full_returning_customer", title: "Full Flow: Returning Customer", description: "Welcome -> Confirmed -> Started -> Completed" },
-  { key: "full_subscription_flow", title: "Full Flow: Subscription", description: "Checkout Link -> Appointment Created -> Admin Notification" },
+  {
+    key: "full_self_serve_booking",
+    title: "Full Flow: Self-Serve Booking",
+    description:
+      "Booking Received -> Deposit Paid -> Confirmed -> Started -> Completed -> Review Request.",
+  },
+  {
+    key: "full_subscription_flow",
+    title: "Full Flow: Subscription",
+    description:
+      "Checkout Link -> Subscription Appointment Created -> Admin visibility.",
+  },
+  {
+    key: "abandoned_checkout_recovery_flow",
+    title: "Full Flow: Abandoned Recovery",
+    description:
+      "Saved draft checkout recovery email for a customer who did not finish payment.",
+  },
 ];
 
 type TestResult = {
@@ -193,28 +280,31 @@ export default function TestNotificationsPage() {
           Test Notifications & Flows
         </h1>
         <p className="text-sm text-muted-foreground">
-          Run end-to-end tests of the notification pipeline. Emails sent to
-          dustin@rivercitymd.com and cg@rocktownlabs.com. SMS sent to admin
-          phone.
+          Run safe internal notification tests against the current production
+          event catalog. These scenarios send test emails to internal inboxes
+          only and mirror the live booking, subscription, failure, and recovery
+          flows without contacting real customers. SMS delivery still rides the
+          live Twilio notification path, so this screen is focused on template
+          and scenario coverage.
         </p>
       </div>
 
       <ScenarioSection
-        title="Customer Emails"
+        title="Booking & Customer Lifecycle"
         scenarios={CUSTOMER_SCENARIOS}
         results={results}
         onRun={handleRun}
       />
 
       <ScenarioSection
-        title="Admin Emails"
+        title="Admin Operations"
         scenarios={ADMIN_SCENARIOS}
         results={results}
         onRun={handleRun}
       />
 
       <ScenarioSection
-        title="Subscription Emails"
+        title="Subscription Notifications"
         scenarios={SUBSCRIPTION_SCENARIOS}
         results={results}
         onRun={handleRun}

--- a/convex/testEmails.tsx
+++ b/convex/testEmails.tsx
@@ -15,9 +15,10 @@ import { resend } from "./emails";
 import { formatTime12h } from "./lib/time";
 
 import {
-  WelcomeEmail,
   AppointmentConfirmationEmail,
   AppointmentReminderEmail,
+  BookingReceivedEmail,
+  AbandonedCheckoutRecoveryEmail,
   AdminNewCustomerNotificationEmail,
   AdminReviewSubmittedNotificationEmail,
   CustomerReviewRequestEmailTemplate,
@@ -27,6 +28,8 @@ import {
   AdminDepositPaidNotificationEmail,
   SubscriptionCheckoutLinkEmail,
   SubscriptionAppointmentCreatedEmail,
+  AdminSubscriptionCheckoutLinkNotificationEmail,
+  AdminPaymentFailedNotificationEmail,
 } from "./emailTemplates";
 
 function shouldSkipEmails(): boolean {
@@ -80,19 +83,6 @@ export const sendTestEmail = internalAction({
     let subject: string;
 
     switch (args.template) {
-      case "welcome": {
-        html = await render(
-          WelcomeEmail({
-            userName: FAKE.customerName,
-            businessName,
-            dashboardUrl: `${site}/dashboard`,
-            logoUrl: logo,
-          }),
-        );
-        subject = `[TEST] Welcome to ${businessName}!`;
-        break;
-      }
-
       case "appointment_confirmation": {
         html = await render(
           AppointmentConfirmationEmail({
@@ -126,6 +116,24 @@ export const sendTestEmail = internalAction({
           }),
         );
         subject = `[TEST] Reminder: Your appointment is tomorrow - ${FAKE.appointmentDate}`;
+        break;
+      }
+
+      case "customer_booking_received": {
+        html = await render(
+          BookingReceivedEmail({
+            customerName: FAKE.customerName,
+            businessName,
+            appointmentDate: FAKE.appointmentDate,
+            appointmentTime: time12h,
+            services: [...FAKE.services],
+            location: FAKE.location,
+            totalPrice: FAKE.totalPrice,
+            dashboardUrl: `${site}/dashboard/appointments`,
+            logoUrl: logo,
+          }),
+        );
+        subject = `[TEST] Booking Received - ${FAKE.appointmentDate}`;
         break;
       }
 
@@ -220,6 +228,22 @@ export const sendTestEmail = internalAction({
         break;
       }
 
+      case "abandoned_checkout_recovery": {
+        html = await render(
+          AbandonedCheckoutRecoveryEmail({
+            customerName: FAKE.customerName,
+            businessName,
+            appointmentDate: FAKE.appointmentDate,
+            appointmentTime: time12h,
+            services: [...FAKE.services],
+            resumeUrl: `${site}/booking/resume?token=test-token`,
+            logoUrl: logo,
+          }),
+        );
+        subject = `[TEST] Finish your booking for ${FAKE.appointmentDate}`;
+        break;
+      }
+
       case "admin_new_customer": {
         html = await render(
           AdminNewCustomerNotificationEmail({
@@ -256,6 +280,29 @@ export const sendTestEmail = internalAction({
           }),
         );
         subject = `[TEST] Deposit Paid - ${FAKE.customerName} - ${FAKE.appointmentDate}`;
+        break;
+      }
+
+      case "admin_booking_received": {
+        html = await render(
+          AdminAppointmentNotificationEmailTemplate({
+            actionText: "Booking Received",
+            customerName: FAKE.customerName,
+            customerEmail: FAKE.customerEmail,
+            customerPhone: FAKE.customerPhone,
+            appointmentDate: FAKE.appointmentDate,
+            appointmentTime: time12h,
+            duration: FAKE.duration,
+            totalPrice: FAKE.totalPrice,
+            serviceNames: [...FAKE.services],
+            location: FAKE.location,
+            status: "pending",
+            businessName,
+            adminUrl: `${site}/admin/appointments`,
+            logoUrl: logo,
+          }),
+        );
+        subject = `[TEST] Booking Received - ${FAKE.appointmentDate} ${time12h}`;
         break;
       }
 
@@ -350,6 +397,24 @@ export const sendTestEmail = internalAction({
         break;
       }
 
+      case "admin_subscription_checkout_link": {
+        html = await render(
+          AdminSubscriptionCheckoutLinkNotificationEmail({
+            customerName: FAKE.customerName,
+            customerEmail: FAKE.customerEmail,
+            businessName,
+            serviceNames: [...FAKE.services],
+            frequency: "monthly",
+            price: FAKE.totalPrice,
+            checkoutUrl: `${site}/dashboard/subscriptions?test=true`,
+            adminUrl: `${site}/admin/subscriptions`,
+            logoUrl: logo,
+          }),
+        );
+        subject = `[TEST] Subscription Checkout Link Sent - ${FAKE.customerName}`;
+        break;
+      }
+
       case "subscription_appointment_created": {
         html = await render(
           SubscriptionAppointmentCreatedEmail({
@@ -364,6 +429,46 @@ export const sendTestEmail = internalAction({
           }),
         );
         subject = `[TEST] Your Upcoming Service is Scheduled — ${FAKE.appointmentDate}`;
+        break;
+      }
+
+      case "admin_subscription_appointment_created": {
+        html = await render(
+          AdminAppointmentNotificationEmailTemplate({
+            actionText: "Subscription Appointment Scheduled",
+            customerName: FAKE.customerName,
+            customerEmail: FAKE.customerEmail,
+            customerPhone: FAKE.customerPhone,
+            appointmentDate: FAKE.appointmentDate,
+            appointmentTime: time12h,
+            duration: FAKE.duration,
+            totalPrice: FAKE.totalPrice,
+            serviceNames: [...FAKE.services],
+            location: FAKE.location,
+            status: "pending",
+            businessName,
+            adminUrl: `${site}/admin/appointments`,
+            logoUrl: logo,
+          }),
+        );
+        subject = `[TEST] Subscription Appointment Scheduled - ${FAKE.appointmentDate}`;
+        break;
+      }
+
+      case "admin_payment_failed": {
+        html = await render(
+          AdminPaymentFailedNotificationEmail({
+            businessName,
+            customerName: FAKE.customerName,
+            customerEmail: FAKE.customerEmail,
+            appointmentSummary: `${FAKE.appointmentDate} at ${time12h}`,
+            failureReason: "Card declined during test payment attempt.",
+            paymentContext: "Invoice payment (test)",
+            adminUrl: `${site}/admin/invoices`,
+            logoUrl: logo,
+          }),
+        );
+        subject = `[TEST] Payment Failed - ${FAKE.customerName}`;
         break;
       }
 

--- a/convex/testFlows.ts
+++ b/convex/testFlows.ts
@@ -129,23 +129,16 @@ export const runTestScenario = internalAction({
 
       switch (args.scenario) {
         // -------------------------------------------------------------------
-        // 1. new_customer_onboarded
+        // 1. booking_received
         // -------------------------------------------------------------------
-        case "new_customer_onboarded": {
-          await sendTest(ctx, "admin_new_customer");
+        case "booking_received": {
+          await sendTest(ctx, "customer_booking_received");
+          await sendTest(ctx, "admin_booking_received");
           break;
         }
 
         // -------------------------------------------------------------------
-        // 2. welcome_email
-        // -------------------------------------------------------------------
-        case "welcome_email": {
-          await sendTest(ctx, "welcome");
-          break;
-        }
-
-        // -------------------------------------------------------------------
-        // 3. deposit_paid
+        // 2. deposit_paid
         // -------------------------------------------------------------------
         case "deposit_paid": {
           await sendTest(ctx, "admin_deposit_paid");
@@ -153,7 +146,7 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 4. appointment_confirmed
+        // 3. appointment_confirmed
         // -------------------------------------------------------------------
         case "appointment_confirmed": {
           await sendTest(ctx, "appointment_confirmation");
@@ -162,7 +155,7 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 5. appointment_cancelled
+        // 4. appointment_cancelled
         // -------------------------------------------------------------------
         case "appointment_cancelled": {
           await sendTest(ctx, "customer_status_cancelled");
@@ -171,7 +164,7 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 6. appointment_rescheduled
+        // 5. appointment_rescheduled
         // -------------------------------------------------------------------
         case "appointment_rescheduled": {
           await sendTest(ctx, "customer_status_rescheduled");
@@ -180,7 +173,7 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 7. appointment_started
+        // 6. appointment_started
         // -------------------------------------------------------------------
         case "appointment_started": {
           await sendTest(ctx, "customer_status_in_progress");
@@ -189,11 +182,19 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 8. appointment_completed
+        // 7. appointment_completed
         // -------------------------------------------------------------------
         case "appointment_completed": {
           await sendTest(ctx, "customer_status_completed");
           await sendTest(ctx, "admin_appointment_completed");
+          await sendTest(ctx, "customer_review_request");
+          break;
+        }
+
+        // -------------------------------------------------------------------
+        // 8. review_request
+        // -------------------------------------------------------------------
+        case "review_request": {
           await sendTest(ctx, "customer_review_request");
           break;
         }
@@ -207,7 +208,15 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 10. review_submitted
+        // 10. abandoned_checkout_recovery
+        // -------------------------------------------------------------------
+        case "abandoned_checkout_recovery": {
+          await sendTest(ctx, "abandoned_checkout_recovery");
+          break;
+        }
+
+        // -------------------------------------------------------------------
+        // 11. review_submitted
         // -------------------------------------------------------------------
         case "review_submitted": {
           await sendTest(ctx, "admin_review_submitted");
@@ -215,7 +224,7 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 11. mileage_log_required
+        // 12. mileage_log_required
         // -------------------------------------------------------------------
         case "mileage_log_required": {
           await sendTest(ctx, "admin_mileage_log_required");
@@ -223,61 +232,71 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 12. subscription_checkout_link
+        // 13. payment_failed
+        // -------------------------------------------------------------------
+        case "payment_failed": {
+          await sendTest(ctx, "admin_payment_failed");
+          break;
+        }
+
+        // -------------------------------------------------------------------
+        // 14. subscription_checkout_link
         // -------------------------------------------------------------------
         case "subscription_checkout_link": {
           await sendTest(ctx, "subscription_checkout_link");
+          await sendTest(ctx, "admin_subscription_checkout_link");
           break;
         }
 
         // -------------------------------------------------------------------
-        // 13. subscription_appointment_created
+        // 15. subscription_appointment_created
         // -------------------------------------------------------------------
         case "subscription_appointment_created": {
           await sendTest(ctx, "subscription_appointment_created");
+          await sendTest(ctx, "admin_subscription_appointment_created");
           break;
         }
 
         // -------------------------------------------------------------------
-        // 14. full_subscription_flow (checkout link → appointment created)
+        // 16. full_subscription_flow (checkout link → appointment created)
         // -------------------------------------------------------------------
         case "full_subscription_flow": {
           // Step 1: checkout link sent
           await sendTest(ctx, "subscription_checkout_link");
+          await sendTest(ctx, "admin_subscription_checkout_link");
           await new Promise((r) => setTimeout(r, 1000));
 
           // Step 2: appointment auto-created after payment
           await sendTest(ctx, "subscription_appointment_created");
+          await sendTest(ctx, "admin_subscription_appointment_created");
           await new Promise((r) => setTimeout(r, 1000));
-
-          // Step 3: admin gets appointment notification
-          await sendTest(ctx, "admin_appointment_confirmed");
           break;
         }
 
         // -------------------------------------------------------------------
-        // 15. full_guest_checkout (1→3→4→7→8)
+        // 17. full_self_serve_booking
         // -------------------------------------------------------------------
-        case "full_guest_checkout": {
-          // Step 1: new customer
-          await sendTest(ctx, "admin_new_customer");
+        case "full_self_serve_booking": {
+          // Step 1: booking received
+          await sendTest(ctx, "customer_booking_received");
+          await sendTest(ctx, "admin_booking_received");
           await new Promise((r) => setTimeout(r, 1000));
 
-          // Step 3: deposit paid
+          // Step 2: deposit paid
           await sendTest(ctx, "admin_deposit_paid");
           await new Promise((r) => setTimeout(r, 1000));
 
-          // Step 4: confirmed
+          // Step 3: confirmed
           await sendTest(ctx, "appointment_confirmation");
           await sendTest(ctx, "admin_appointment_confirmed");
           await new Promise((r) => setTimeout(r, 1000));
 
-          // Step 7: started
+          // Step 4: started
           await sendTest(ctx, "customer_status_in_progress");
           await sendTest(ctx, "admin_appointment_started");
           await new Promise((r) => setTimeout(r, 1000));
 
-          // Step 8: completed
+          // Step 5: completed
           await sendTest(ctx, "customer_status_completed");
           await sendTest(ctx, "admin_appointment_completed");
           await sendTest(ctx, "customer_review_request");
@@ -285,27 +304,10 @@ export const runTestScenario = internalAction({
         }
 
         // -------------------------------------------------------------------
-        // 13. full_returning_customer (2→4→7→8)
+        // 18. abandoned_checkout_recovery_flow
         // -------------------------------------------------------------------
-        case "full_returning_customer": {
-          // Step 2: welcome
-          await sendTest(ctx, "welcome");
-          await new Promise((r) => setTimeout(r, 1000));
-
-          // Step 4: confirmed
-          await sendTest(ctx, "appointment_confirmation");
-          await sendTest(ctx, "admin_appointment_confirmed");
-          await new Promise((r) => setTimeout(r, 1000));
-
-          // Step 7: started
-          await sendTest(ctx, "customer_status_in_progress");
-          await sendTest(ctx, "admin_appointment_started");
-          await new Promise((r) => setTimeout(r, 1000));
-
-          // Step 8: completed
-          await sendTest(ctx, "customer_status_completed");
-          await sendTest(ctx, "admin_appointment_completed");
-          await sendTest(ctx, "customer_review_request");
+        case "abandoned_checkout_recovery_flow": {
+          await sendTest(ctx, "abandoned_checkout_recovery");
           break;
         }
 


### PR DESCRIPTION
## Summary

Align /admin/test with the current notification and recovery flows.

## Implementation Notes

- replace stale welcome/onboarding scenarios with live booking, recovery, subscription, and payment-failure cases
- add isolated test templates for booking received, abandoned checkout recovery, admin subscription alerts, and payment failed
- clarify that the admin test page is focused on safe internal email scenario coverage

## Testing Notes

- pnpm exec tsc --noEmit
- pnpm lint

Closes #0