### PR TITLE
feat: add pet fee to booking

### DIFF
--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -116,6 +116,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
   const [editServiceIds, setEditServiceIds] = useState<Id<"services">[]>([]);
   const [editVehicleIds, setEditVehicleIds] = useState<Id<"vehicles">[]>([]);
   const [editVehicleSizes, setEditVehicleSizes] = useState<Record<string, string>>({});
+  const [editPetFeeVehicleIds, setEditPetFeeVehicleIds] = useState<Id<"vehicles">[]>([]);
 
   useEffect(() => {
     if (!data?.invoice) return;
@@ -192,6 +193,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
             ? [customerVehiclesQuery[0]._id]
             : []),
     );
+    setEditPetFeeVehicleIds(data.petFeeVehicleIds ?? []);
     const sizes: Record<string, string> = {};
     for (const v of customerVehiclesQuery || data.vehicles) {
       sizes[v._id] = v.size || "medium";
@@ -237,6 +239,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
         zip: editZip,
         locationNotes: editLocationNotes || undefined,
         notes: editNotes || undefined,
+        petFeeVehicleIds: editPetFeeVehicleIds,
       });
 
       toast.success("Appointment updated — pricing recalculated");
@@ -261,6 +264,22 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     setEditVehicleIds((prev) =>
       checked ? [...prev, vehicleId] : prev.filter((id) => id !== vehicleId),
     );
+    if (!checked) {
+      setEditPetFeeVehicleIds((prev) => prev.filter((id) => id !== vehicleId));
+    }
+  };
+
+  const togglePetFeeVehicle = (vehicleId: Id<"vehicles">, checked: boolean) => {
+    if (checked) {
+      setEditVehicleIds((prev) =>
+        prev.includes(vehicleId) ? prev : [...prev, vehicleId],
+      );
+      setEditPetFeeVehicleIds((prev) =>
+        prev.includes(vehicleId) ? prev : [...prev, vehicleId],
+      );
+      return;
+    }
+    setEditPetFeeVehicleIds((prev) => prev.filter((id) => id !== vehicleId));
   };
 
   const handleBillingSave = async (reissue: boolean) => {
@@ -522,6 +541,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                 <div className="space-y-3">
                   {customerVehicles.map((v) => {
                     const checked = editVehicleIds.includes(v._id);
+                    const hasPetFee = editPetFeeVehicleIds.includes(v._id);
                     return (
                       <div
                         key={v._id}
@@ -563,6 +583,17 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                             </SelectContent>
                           </Select>
                         </div>
+                        <div className="mt-3 flex items-center gap-2 border-t pt-3">
+                          <Checkbox
+                            checked={hasPetFee}
+                            onCheckedChange={(value) =>
+                              togglePetFeeVehicle(v._id, value === true)
+                            }
+                          />
+                          <span className="text-sm text-muted-foreground">
+                            Apply pet fee to this vehicle
+                          </span>
+                        </div>
                       </div>
                     );
                   })}
@@ -587,6 +618,9 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                     <Badge variant="secondary" className="capitalize">
                       {v.size || "medium"}
                     </Badge>
+                    {(data.petFeeVehicleIds ?? []).includes(v._id) && (
+                      <Badge variant="outline">Pet fee</Badge>
+                    )}
                   </div>
                 ))}
               </div>

--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -590,9 +590,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                               togglePetFeeVehicle(v._id, value === true)
                             }
                           />
-                          <span className="text-sm text-muted-foreground">
-                            Apply pet fee to this vehicle
-                          </span>
+                          
                         </div>
                       </div>
                     );

--- a/components/admin/services-client.tsx
+++ b/components/admin/services-client.tsx
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
   DialogContent,
@@ -72,6 +74,8 @@ export default function ServicesClient() {
   const updateService = useMutation(api.services.update);
   const depositSettings = useQuery(api.depositSettings.get);
   const updateDepositSettings = useMutation(api.depositSettings.upsert);
+  const petFeeSettings = useQuery(api.petFeeSettings.get);
+  const updatePetFeeSettings = useMutation(api.petFeeSettings.upsert);
 
   const [showServiceTypeDialog, setShowServiceTypeDialog] = useState(false);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -84,12 +88,25 @@ export default function ServicesClient() {
 
   const [isEditingDeposit, setIsEditingDeposit] = useState(false);
   const [depositAmount, setDepositAmount] = useState(depositSettings?.amountPerVehicle ?? 50);
+  const [isEditingPetFee, setIsEditingPetFee] = useState(false);
+  const [petFeePrices, setPetFeePrices] = useState({
+    basePriceSmall: 50,
+    basePriceMedium: 50,
+    basePriceLarge: 50,
+    isActive: true,
+  });
 
   useEffect(() => {
     if (depositSettings) {
       setDepositAmount(depositSettings.amountPerVehicle);
     }
   }, [depositSettings]);
+
+  useEffect(() => {
+    if (petFeeSettings) {
+      setPetFeePrices(petFeeSettings);
+    }
+  }, [petFeeSettings]);
 
   if (servicesQuery === undefined) {
     return (
@@ -164,6 +181,12 @@ export default function ServicesClient() {
     if (medium !== undefined) parts.push(`M $${medium.toFixed(0)}`);
     if (large !== undefined) parts.push(`L $${large.toFixed(0)}`);
     return parts.join(" • ") || "N/A";
+  };
+
+  const formatPetFeePricing = () => {
+    const settings = petFeeSettings ?? petFeePrices;
+    if (!settings.isActive) return "Pet fee off";
+    return `Pet fee: S $${settings.basePriceSmall.toFixed(0)} • M $${settings.basePriceMedium.toFixed(0)} • L $${settings.basePriceLarge.toFixed(0)}`;
   };
 
   const popularityBadgeClass = (popularity?: string) => {
@@ -391,6 +414,74 @@ export default function ServicesClient() {
                 Deposit: ${depositSettings?.amountPerVehicle ?? 50} per vehicle
               </span>
               <Button size="sm" variant="ghost" onClick={() => setIsEditingDeposit(true)}>
+                <Edit className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+          {isEditingPetFee ? (
+            <div className="flex flex-wrap items-end gap-2 rounded-md border p-2">
+              <div className="flex items-center gap-2 pb-2">
+                <Switch
+                  checked={petFeePrices.isActive}
+                  onCheckedChange={(checked) =>
+                    setPetFeePrices((current) => ({ ...current, isActive: checked }))
+                  }
+                />
+                <span className="text-sm text-muted-foreground">Pet fee</span>
+              </div>
+              {[
+                ["basePriceSmall", "Small"],
+                ["basePriceMedium", "Medium"],
+                ["basePriceLarge", "Large"],
+              ].map(([key, label]) => (
+                <div key={key} className="space-y-1">
+                  <Label className="text-xs">{label}</Label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    value={petFeePrices[key as keyof typeof petFeePrices] as number}
+                    onChange={(event) =>
+                      setPetFeePrices((current) => ({
+                        ...current,
+                        [key]: parseFloat(event.target.value) || 0,
+                      }))
+                    }
+                    className="w-20"
+                  />
+                </div>
+              ))}
+              <Button
+                size="sm"
+                onClick={async () => {
+                  try {
+                    await updatePetFeeSettings(petFeePrices);
+                    setIsEditingPetFee(false);
+                    toast.success("Pet fee updated");
+                    router.refresh();
+                  } catch {
+                    toast.error("Failed to update pet fee");
+                  }
+                }}
+              >
+                <Save className="h-4 w-4" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsEditingPetFee(false);
+                  if (petFeeSettings) setPetFeePrices(petFeeSettings);
+                }}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                {formatPetFeePricing()}
+              </span>
+              <Button size="sm" variant="ghost" onClick={() => setIsEditingPetFee(true)}>
                 <Edit className="h-4 w-4" />
               </Button>
             </div>

--- a/components/dashboard/invoices-client.tsx
+++ b/components/dashboard/invoices-client.tsx
@@ -43,7 +43,8 @@ type Invoice = {
   userId: Id<"users">;
   invoiceNumber: string;
   items: Array<{
-    serviceId: Id<"services">;
+    itemType?: "service" | "pet_fee";
+    serviceId?: Id<"services">;
     serviceName: string;
     quantity: number;
     unitPrice: number;

--- a/components/forms/admin/add-appointment-form.tsx
+++ b/components/forms/admin/add-appointment-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -65,6 +65,7 @@ export function AddAppointmentForm({
 }: AddAppointmentFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isCreatingVehicle, setIsCreatingVehicle] = useState(false);
+  const [petFeeVehicleIds, setPetFeeVehicleIds] = useState<Id<"vehicles">[]>([]);
   const [newVehicle, setNewVehicle] = useState({
     year: "",
     make: "",
@@ -103,6 +104,12 @@ export function AddAppointmentForm({
     selectedUserId ? { userId: selectedUserId as Id<"users"> } : "skip",
   );
 
+  useEffect(() => {
+    if (!open) {
+      setPetFeeVehicleIds([]);
+    }
+  }, [open]);
+
   const resetVehicleForm = () => {
     setNewVehicle({
       year: "",
@@ -118,6 +125,7 @@ export function AddAppointmentForm({
   const handleCustomerChange = (userId: string) => {
     form.setValue("userId", userId, { shouldValidate: true });
     form.setValue("vehicleIds", [], { shouldValidate: true });
+    setPetFeeVehicleIds([]);
     resetVehicleForm();
 
     const selectedClient = clients?.find((client) => client._id === userId);
@@ -181,10 +189,12 @@ export function AddAppointmentForm({
         zip: data.zip,
         locationNotes: data.locationNotes,
         notes: data.notes,
+        petFeeVehicleIds,
       });
 
       toast.success("Appointment created successfully");
       form.reset();
+      setPetFeeVehicleIds([]);
       onOpenChange(false);
     } catch {
       toast.error("Failed to create appointment");
@@ -262,6 +272,9 @@ export function AddAppointmentForm({
                                               (id) => id !== vehicle._id,
                                             ),
                                           );
+                                          setPetFeeVehicleIds((ids) =>
+                                            ids.filter((id) => id !== vehicle._id),
+                                          );
                                         }
                                       }}
                                     />
@@ -269,6 +282,29 @@ export function AddAppointmentForm({
                                   <FormLabel className="text-sm font-normal">
                                     {vehicle.year} {vehicle.make} {vehicle.model}
                                   </FormLabel>
+                                  <div className="ml-auto flex items-center gap-2">
+                                    <Checkbox
+                                      checked={petFeeVehicleIds.includes(vehicle._id)}
+                                      onCheckedChange={(checked) => {
+                                        const selectedVehicleIds = field.value || [];
+                                        if (checked) {
+                                          if (!selectedVehicleIds.includes(vehicle._id)) {
+                                            field.onChange([...selectedVehicleIds, vehicle._id]);
+                                          }
+                                          setPetFeeVehicleIds((ids) =>
+                                            ids.includes(vehicle._id)
+                                              ? ids
+                                              : [...ids, vehicle._id],
+                                          );
+                                        } else {
+                                          setPetFeeVehicleIds((ids) =>
+                                            ids.filter((id) => id !== vehicle._id),
+                                          );
+                                        }
+                                      }}
+                                    />
+                                    <span className="text-xs text-muted-foreground">Pet fee</span>
+                                  </div>
                                 </FormItem>
                               )}
                             />

--- a/components/forms/dashboard/dashboard-appointment-form.tsx
+++ b/components/forms/dashboard/dashboard-appointment-form.tsx
@@ -506,9 +506,7 @@ export function DashboardAppointmentForm({
                 <div className="flex items-center justify-between gap-4">
                   <div>
                     <p className="text-sm font-medium">Pet hair or pet travel</p>
-                    <p className="text-xs text-muted-foreground">
-                      Add the configured pet fee for this vehicle.
-                    </p>
+                    
                   </div>
                   <Switch checked={hasPetFee} onCheckedChange={setHasPetFee} />
                 </div>

--- a/components/forms/dashboard/dashboard-appointment-form.tsx
+++ b/components/forms/dashboard/dashboard-appointment-form.tsx
@@ -70,6 +70,7 @@ export function DashboardAppointmentForm({
   const [selectedStandardId, setSelectedStandardId] = useState<string | null>(
     null,
   );
+  const [hasPetFee, setHasPetFee] = useState(false);
   const [scheduledDate, setScheduledDate] = useState("");
   const [scheduledTime, setScheduledTime] = useState("");
   const [street, setStreet] = useState("");
@@ -86,6 +87,7 @@ export function DashboardAppointmentForm({
   const currentUser = useQuery(api.users.getCurrentUser);
   const userVehicles = useQuery(api.vehicles.getMyVehicles);
   const services = useQuery(api.services.list);
+  const petFeeSettings = useQuery(api.petFeeSettings.get);
   const nextBookableDate = useQuery(api.availability.getNextBookableDate, {});
 
   // Mutations/Actions
@@ -130,6 +132,7 @@ export function DashboardAppointmentForm({
       setSelectedVehicleId(null);
       setSelectedServiceIds([]);
       setSelectedStandardId(null);
+      setHasPetFee(false);
       setScheduledDate("");
       setScheduledTime("");
       setLocationNotes("");
@@ -195,8 +198,21 @@ export function DashboardAppointmentForm({
     [selectedServicesData, vehicleSize],
   );
 
+  const petFeeTotal = useMemo(() => {
+    if (!hasPetFee) return 0;
+    if (petFeeSettings?.isActive === false) return 0;
+    if (vehicleSize === "small") {
+      return petFeeSettings?.basePriceSmall ?? petFeeSettings?.basePriceMedium ?? 50;
+    }
+    if (vehicleSize === "large") {
+      return petFeeSettings?.basePriceLarge ?? petFeeSettings?.basePriceMedium ?? 50;
+    }
+    return petFeeSettings?.basePriceMedium ?? 50;
+  }, [hasPetFee, petFeeSettings, vehicleSize]);
+
   const depositTotal = 50; // $50 deposit per vehicle
-  const dueNow = paymentOption === "full" ? serviceTotal : depositTotal;
+  const orderTotal = serviceTotal + petFeeTotal;
+  const dueNow = paymentOption === "full" ? orderTotal : Math.min(depositTotal, orderTotal);
 
   // Step validation
   const canAdvance = (step: number): boolean => {
@@ -251,6 +267,9 @@ export function DashboardAppointmentForm({
           notes: locationNotes || undefined,
         },
         existingVehicleIds: [selectedVehicleId] as Id<"vehicles">[],
+        petFeeExistingVehicleIds: hasPetFee
+          ? ([selectedVehicleId] as Id<"vehicles">[])
+          : [],
         serviceIds: allSelectedServiceIds as Id<"services">[],
         scheduledDate,
         scheduledTime,
@@ -483,11 +502,20 @@ export function DashboardAppointmentForm({
 
             {/* Running total */}
             {allSelectedServiceIds.length > 0 && (
-              <div className="bg-muted/50 p-3 rounded-lg border border-border/50 mt-4">
+              <div className="space-y-3 bg-muted/50 p-3 rounded-lg border border-border/50 mt-4">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">Pet hair or pet travel</p>
+                    <p className="text-xs text-muted-foreground">
+                      Add the configured pet fee for this vehicle.
+                    </p>
+                  </div>
+                  <Switch checked={hasPetFee} onCheckedChange={setHasPetFee} />
+                </div>
                 <div className="flex justify-between items-center">
                   <span className="text-sm font-medium">Running Total</span>
                   <span className="font-bold text-lg text-primary">
-                    ${serviceTotal.toFixed(2)}
+                    ${orderTotal.toFixed(2)}
                   </span>
                 </div>
               </div>
@@ -622,6 +650,16 @@ export function DashboardAppointmentForm({
                 <span>Service Total</span>
                 <span>${serviceTotal.toFixed(2)}</span>
               </div>
+              {petFeeTotal > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Pet fee</span>
+                  <span className="font-medium">${petFeeTotal.toFixed(2)}</span>
+                </div>
+              )}
+              <div className="border-t pt-2 flex justify-between text-sm font-semibold">
+                <span>Total</span>
+                <span>${orderTotal.toFixed(2)}</span>
+              </div>
 
               {/* Date/Time */}
               <div className="border-t pt-2 flex justify-between text-sm">
@@ -665,7 +703,7 @@ export function DashboardAppointmentForm({
                       Pay Deposit Now
                     </span>
                     <span className="text-xs text-muted-foreground block">
-                      ${depositTotal.toFixed(2)} deposit now, remaining balance
+                      ${Math.min(depositTotal, orderTotal).toFixed(2)} deposit now, remaining balance
                       invoiced after service
                     </span>
                   </div>
@@ -691,7 +729,7 @@ export function DashboardAppointmentForm({
                       Pay Full Price Now
                     </span>
                     <span className="text-xs text-muted-foreground block">
-                      ${serviceTotal.toFixed(2)} — pay entire amount upfront
+                      ${orderTotal.toFixed(2)} — pay entire amount upfront
                     </span>
                   </div>
                 </label>
@@ -716,7 +754,7 @@ export function DashboardAppointmentForm({
                       Pay Remaining in Person
                     </span>
                     <span className="text-xs text-muted-foreground block">
-                      ${depositTotal.toFixed(2)} deposit now, pay balance in
+                      ${Math.min(depositTotal, orderTotal).toFixed(2)} deposit now, pay balance in
                       cash/card at service
                     </span>
                   </div>
@@ -750,7 +788,7 @@ export function DashboardAppointmentForm({
               {paymentOption === "in_person" && (
                 <p className="text-xs text-muted-foreground mt-1">
                   Remaining balance of $
-                  {(serviceTotal - depositTotal).toFixed(2)} will be collected
+                  {Math.max(0, orderTotal - depositTotal).toFixed(2)} will be collected
                   in person.
                 </p>
               )}

--- a/components/home/appointment-modal.tsx
+++ b/components/home/appointment-modal.tsx
@@ -99,6 +99,7 @@ const step3Schema = z.object({
         color: z.string().optional(),
         licensePlate: z.string().optional(),
         size: z.enum(["small", "medium", "large"]).optional(),
+        hasPet: z.boolean().optional(),
         type: z.enum(["car", "truck", "suv"]),
       }),
     )
@@ -172,6 +173,7 @@ export default function AppointmentModal({
   */
 
   const services = useQuery(api.services.list);
+  const petFeeSettings = useQuery(api.petFeeSettings.get);
   const bookingReadiness = useQuery(api.setupReadiness.getPublicBookingReadiness);
   const nextBookableDate = useQuery(
     api.availability.getNextBookableDate,
@@ -202,7 +204,16 @@ export default function AppointmentModal({
     resolver: zodResolver(step3Schema),
     defaultValues: {
       vehicles: (step3Data?.vehicles || [
-        { year: "", make: "", model: "", color: "", licensePlate: "", type: "car", size: "small" },
+        {
+          year: "",
+          make: "",
+          model: "",
+          color: "",
+          licensePlate: "",
+          type: "car",
+          size: "small",
+          hasPet: false,
+        },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any,
     },
@@ -325,7 +336,16 @@ export default function AppointmentModal({
     const currentVehicles = step3Form.getValues("vehicles") || [];
     step3Form.setValue("vehicles", [
       ...currentVehicles,
-      { year: "", make: "", model: "", color: "", licensePlate: "", type: "car", size: "small" },
+      {
+        year: "",
+        make: "",
+        model: "",
+        color: "",
+        licensePlate: "",
+        type: "car",
+        size: "small",
+        hasPet: false,
+      },
     ]);
   };
 
@@ -460,6 +480,7 @@ export default function AppointmentModal({
           size: vehicle.size,
           color: vehicle.color,
           licensePlate: vehicle.licensePlate,
+          hasPet: vehicle.hasPet ?? false,
         })),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         serviceIds: (step4Data?.serviceIds || []) as any,
@@ -1020,6 +1041,33 @@ export default function AppointmentModal({
                           </FormItem>
                         )}
                       />
+                      <FormField
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        control={step3Form.control as any}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        name={`vehicles.${index}.hasPet` as any}
+                        render={({ field }) => (
+                          <FormItem className="rounded-lg border p-4">
+                            <div className="flex items-center justify-between gap-4">
+                              <div className="space-y-1">
+                                <FormLabel className="mb-0">
+                                  Pet hair or pet travel
+                                </FormLabel>
+                                <p className="text-sm text-muted-foreground">
+                                  Adds the configured pet fee for this vehicle.
+                                </p>
+                              </div>
+                              <FormControl>
+                                <Switch
+                                  checked={field.value === true}
+                                  onCheckedChange={field.onChange}
+                                />
+                              </FormControl>
+                            </div>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
                     </CardContent>
                   </Card>
                 ))}
@@ -1191,6 +1239,16 @@ export default function AppointmentModal({
           const vehicleCount = step3Data?.vehicles?.length ?? 1;
           const depositPerVehicle = 50;
           const depositTotal = depositPerVehicle * vehicleCount;
+          const petFeeForSize = (size: "small" | "medium" | "large") => {
+            if (petFeeSettings?.isActive === false) return 0;
+            if (size === "small") {
+              return petFeeSettings?.basePriceSmall ?? petFeeSettings?.basePriceMedium ?? 50;
+            }
+            if (size === "large") {
+              return petFeeSettings?.basePriceLarge ?? petFeeSettings?.basePriceMedium ?? 50;
+            }
+            return petFeeSettings?.basePriceMedium ?? 50;
+          };
 
           const selectedServices = services?.filter((s) =>
             step4Data?.serviceIds?.includes(s._id),
@@ -1204,8 +1262,13 @@ export default function AppointmentModal({
                   : service.basePriceLarge;
             return sum + (price ?? 0);
           }, 0) * vehicleCount;
+          const petFeeTotal = (step3Data?.vehicles ?? []).reduce((sum, vehicle) => {
+            if (!vehicle.hasPet) return sum;
+            return sum + petFeeForSize(vehicle.size ?? "medium");
+          }, 0);
+          const orderTotal = serviceTotal + petFeeTotal;
 
-          const dueNow = paymentOption === "full" ? serviceTotal : depositTotal;
+          const dueNow = paymentOption === "full" ? orderTotal : Math.min(depositTotal, orderTotal);
 
           return (
           <div className="space-y-6">
@@ -1241,6 +1304,16 @@ export default function AppointmentModal({
                    <span>Service Total</span>
                    <span>${serviceTotal.toFixed(2)}</span>
                  </div>
+                 {petFeeTotal > 0 && (
+                   <div className="flex justify-between text-sm font-medium mt-1">
+                     <span>Pet Fee</span>
+                     <span>${petFeeTotal.toFixed(2)}</span>
+                   </div>
+                 )}
+                 <div className="flex justify-between border-t pt-2 text-sm font-semibold mt-2">
+                   <span>Total</span>
+                   <span>${orderTotal.toFixed(2)}</span>
+                 </div>
              </div>
 
              {/* Payment Option Selector */}
@@ -1265,7 +1338,7 @@ export default function AppointmentModal({
                    <div>
                      <span className="font-medium text-sm">Pay Deposit Now</span>
                      <span className="text-xs text-muted-foreground block">
-                       ${depositTotal.toFixed(2)} deposit now, remaining balance invoiced after service
+                       ${Math.min(depositTotal, orderTotal).toFixed(2)} deposit now, remaining balance invoiced after service
                      </span>
                    </div>
                  </label>
@@ -1287,7 +1360,7 @@ export default function AppointmentModal({
                    <div>
                      <span className="font-medium text-sm">Pay Full Price Now</span>
                      <span className="text-xs text-muted-foreground block">
-                       ${serviceTotal.toFixed(2)} — pay entire amount upfront
+                       ${orderTotal.toFixed(2)} — pay entire amount upfront
                      </span>
                    </div>
                  </label>
@@ -1309,7 +1382,7 @@ export default function AppointmentModal({
                    <div>
                      <span className="font-medium text-sm">Pay Remaining in Person</span>
                      <span className="text-xs text-muted-foreground block">
-                       ${depositTotal.toFixed(2)} deposit now, pay balance in cash/card at service
+                       ${Math.min(depositTotal, orderTotal).toFixed(2)} deposit now, pay balance in cash/card at service
                      </span>
                    </div>
                  </label>
@@ -1334,7 +1407,7 @@ export default function AppointmentModal({
                  )}
                  {paymentOption === "in_person" && (
                    <p className="text-xs text-muted-foreground mt-1">
-                     Remaining balance of ${(serviceTotal - depositTotal).toFixed(2)} will be collected in person.
+                     Remaining balance of ${Math.max(0, orderTotal - depositTotal).toFixed(2)} will be collected in person.
                    </p>
                  )}
              </div>

--- a/components/home/appointment-modal.tsx
+++ b/components/home/appointment-modal.tsx
@@ -1053,9 +1053,7 @@ export default function AppointmentModal({
                                 <FormLabel className="mb-0">
                                   Pet hair or pet travel
                                 </FormLabel>
-                                <p className="text-sm text-muted-foreground">
-                                  Adds the configured pet fee for this vehicle.
-                                </p>
+                                
                               </div>
                               <FormControl>
                                 <Switch

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as lib_pricing from "../lib/pricing.js";
 import type * as lib_time from "../lib/time.js";
 import type * as notifications from "../notifications.js";
 import type * as payments from "../payments.js";
+import type * as petFeeSettings from "../petFeeSettings.js";
 import type * as r2 from "../r2.js";
 import type * as reviews from "../reviews.js";
 import type * as services from "../services.js";
@@ -72,6 +73,7 @@ declare const fullApi: ApiFromModules<{
   "lib/time": typeof lib_time;
   notifications: typeof notifications;
   payments: typeof payments;
+  petFeeSettings: typeof petFeeSettings;
   r2: typeof r2;
   reviews: typeof reviews;
   services: typeof services;

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -144,6 +144,150 @@ describe("appointments", () => {
     });
   });
 
+  test("create and update appointment with pet fee vehicles", async () => {
+    const t = convexTest(schema, modules);
+    await seedBookingSetup(t, {
+      includeBookableService: false,
+      includeDepositSettings: true,
+    });
+
+    const userId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        name: "Pet Owner",
+        email: "pet-owner@example.com",
+        role: "client",
+        timesServiced: 0,
+        totalSpent: 0,
+        status: "active",
+      });
+    });
+    const adminId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-pet@example.com",
+        role: "admin",
+      });
+    });
+    const serviceId = await t.run(async (ctx) => {
+      await ctx.db.insert("petFeeSettings", {
+        basePriceSmall: 25,
+        basePriceMedium: 50,
+        basePriceLarge: 75,
+        isActive: true,
+      });
+      return await ctx.db.insert("services", {
+        name: "Pet Fee Test Detail",
+        description: "Detail with pet fee",
+        basePrice: 100,
+        basePriceSmall: 100,
+        basePriceMedium: 100,
+        basePriceLarge: 100,
+        duration: 60,
+        serviceType: "standard",
+        isActive: true,
+      });
+    });
+    const [smallVehicleId, largeVehicleId] = await t.run(async (ctx) => {
+      const small = await ctx.db.insert("vehicles", {
+        userId,
+        year: 2020,
+        make: "Toyota",
+        model: "Corolla",
+        size: "small",
+      });
+      const large = await ctx.db.insert("vehicles", {
+        userId,
+        year: 2022,
+        make: "Ford",
+        model: "F-150",
+        size: "large",
+      });
+      return [small, large];
+    });
+
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-pet@example.com",
+    });
+    const { appointmentId } = await asAdmin.mutation(api.appointments.create, {
+      userId,
+      vehicleIds: [smallVehicleId, largeVehicleId],
+      serviceIds: [serviceId],
+      scheduledDate: APPOINTMENT_TEST_DATE,
+      scheduledTime: "10:00",
+      street: "123 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62701",
+      petFeeVehicleIds: [smallVehicleId, largeVehicleId],
+    });
+
+    const created = await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      const invoice = await ctx.db
+        .query("invoices")
+        .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
+        .unique();
+      return { appointment, invoice };
+    });
+
+    expect(created.appointment?.totalPrice).toBe(300);
+    expect(created.appointment?.petFeeVehicleIds).toEqual([
+      smallVehicleId,
+      largeVehicleId,
+    ]);
+    expect(created.invoice?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "pet_fee",
+          serviceName: "Pet fee - Small vehicle",
+          unitPrice: 25,
+          totalPrice: 25,
+        }),
+        expect.objectContaining({
+          itemType: "pet_fee",
+          serviceName: "Pet fee - Large vehicle",
+          unitPrice: 75,
+          totalPrice: 75,
+        }),
+      ]),
+    );
+
+    await asAdmin.mutation(api.appointments.update, {
+      appointmentId,
+      userId,
+      vehicleIds: [smallVehicleId, largeVehicleId],
+      serviceIds: [serviceId],
+      scheduledDate: APPOINTMENT_TEST_DATE,
+      scheduledTime: "10:00",
+      street: "123 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62701",
+      petFeeVehicleIds: [largeVehicleId],
+    });
+
+    const updated = await t.run(async (ctx) => {
+      const appointment = await ctx.db.get(appointmentId);
+      const invoice = await ctx.db
+        .query("invoices")
+        .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
+        .unique();
+      return { appointment, invoice };
+    });
+
+    expect(updated.appointment?.totalPrice).toBe(275);
+    expect(updated.appointment?.petFeeVehicleIds).toEqual([largeVehicleId]);
+    expect(updated.invoice?.items.filter((item) => item.itemType === "pet_fee")).toEqual([
+      expect.objectContaining({
+        serviceName: "Pet fee - Large vehicle",
+        quantity: 1,
+        unitPrice: 75,
+        totalPrice: 75,
+      }),
+    ]);
+  });
+
   test("list appointments", async () => {
     const t = convexTest(schema, modules);
     await seedBookingSetup(t);

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -11,7 +11,12 @@ import { getUserIdFromIdentity, requireAdmin, isAdmin } from "./auth";
 import { api, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { BOOKING_BLOCK_MINUTES, normalizeDateKey } from "./lib/booking";
-import { getEffectiveServicePrice, normalizeServiceType, type VehicleSize } from "./lib/pricing";
+import {
+  getEffectivePetFeePrice,
+  getEffectiveServicePrice,
+  normalizeServiceType,
+  type VehicleSize,
+} from "./lib/pricing";
 
 interface StripeInvoiceVehicleInput {
   size?: "small" | "medium" | "large";
@@ -21,6 +26,38 @@ function getVehicleSize(
   vehicles: Array<StripeInvoiceVehicleInput>,
 ): "small" | "medium" | "large" {
   return vehicles[0]?.size || "medium";
+}
+
+function formatVehicleSizeLabel(size: VehicleSize) {
+  if (size === "small") return "Small";
+  if (size === "large") return "Large";
+  return "Medium";
+}
+
+async function buildPetFeeItems(
+  ctx: any,
+  vehicles: Array<{ _id: Id<"vehicles">; size?: VehicleSize }>,
+  petFeeVehicleIds: Id<"vehicles">[],
+) {
+  const petFeeSettings = await ctx.runQuery(internal.petFeeSettings.getInternal, {});
+  const petFeeVehicleIdSet = new Set(petFeeVehicleIds);
+  const petFeeSizes = vehicles
+    .filter((vehicle) => petFeeVehicleIdSet.has(vehicle._id))
+    .map((vehicle) => vehicle.size ?? "medium");
+
+  return (["small", "medium", "large"] as VehicleSize[])
+    .map((size) => {
+      const quantity = petFeeSizes.filter((petFeeSize) => petFeeSize === size).length;
+      const unitPrice = getEffectivePetFeePrice(petFeeSettings, size);
+      return {
+        itemType: "pet_fee" as const,
+        serviceName: `Pet fee - ${formatVehicleSizeLabel(size)} vehicle`,
+        quantity,
+        unitPrice,
+        totalPrice: unitPrice * quantity,
+      };
+    })
+    .filter((item) => item.quantity > 0 && item.totalPrice > 0);
 }
 
 function shouldScheduleNotificationJobs(): boolean {
@@ -461,6 +498,7 @@ export const create = mutation({
     zip: v.string(),
     locationNotes: v.optional(v.string()),
     notes: v.optional(v.string()),
+    petFeeVehicleIds: v.optional(v.array(v.id("vehicles"))),
   },
   returns: v.object({
     appointmentId: v.id("appointments"),
@@ -505,6 +543,14 @@ export const create = mutation({
     if (validVehicles.some((vehicle) => vehicle.userId !== args.userId)) {
       throw new Error("Invalid vehicle selection");
     }
+    const petFeeVehicleIds = args.petFeeVehicleIds ?? [];
+    const selectedVehicleIdSet = new Set(args.vehicleIds);
+    if (petFeeVehicleIds.some((vehicleId) => !selectedVehicleIdSet.has(vehicleId))) {
+      throw new ConvexError({
+        code: "SERVICE_NOT_BOOKABLE",
+        message: "Pet fee vehicles must be included in this appointment.",
+      });
+    }
     const vehicleSize = getVehicleSize(validVehicles);
 
     const services = await Promise.all(args.serviceIds.map((id) => ctx.db.get(id)));
@@ -525,15 +571,26 @@ export const create = mutation({
       });
     }
 
-    const totalPrice =
-      validServices.reduce(
-        (sum, service) => sum + getEffectiveServicePrice(service, vehicleSize),
-        0,
-      ) * args.vehicleIds.length;
     const duration = validServices.reduce(
       (sum, service) => sum + (service.duration || 0),
       0,
     );
+
+    const serviceItems = validServices.map((service) => {
+      const unitPrice = getEffectiveServicePrice(service, vehicleSize);
+
+      return {
+        itemType: "service" as const,
+        serviceId: service._id,
+        serviceName: service.name,
+        quantity: args.vehicleIds.length,
+        unitPrice,
+        totalPrice: unitPrice * args.vehicleIds.length,
+      };
+    });
+    const petFeeItems = await buildPetFeeItems(ctx, validVehicles, petFeeVehicleIds);
+    const items = [...serviceItems, ...petFeeItems];
+    const totalPrice = items.reduce((sum, item) => sum + item.totalPrice, 0);
 
     const appointmentId: Id<"appointments"> = await ctx.db.insert(
       "appointments",
@@ -555,6 +612,7 @@ export const create = mutation({
         totalPrice,
         notes: args.notes,
         createdBy: authUserId,
+        petFeeVehicleIds,
       },
     );
 
@@ -563,19 +621,6 @@ export const create = mutation({
 
     // Note: User stats (timesServiced, totalSpent) should be updated when appointment is completed,
     // not when appointment is created. This is handled in the appointment completion flow.
-
-    // Calculate invoice items
-    const items = validServices.map((service) => {
-      const unitPrice = getEffectiveServicePrice(service, vehicleSize);
-
-      return {
-        serviceId: service._id,
-        serviceName: service.name,
-        quantity: args.vehicleIds.length,
-        unitPrice,
-        totalPrice: unitPrice * args.vehicleIds.length,
-      };
-    });
 
     const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0);
     const tax = 0;
@@ -650,6 +695,7 @@ export const update = mutation({
     zip: v.string(),
     locationNotes: v.optional(v.string()),
     notes: v.optional(v.string()),
+    petFeeVehicleIds: v.optional(v.array(v.id("vehicles"))),
   },
   handler: async (ctx, args) => {
     const userId = await getUserIdFromIdentity(ctx);
@@ -671,13 +717,36 @@ export const update = mutation({
     const vehicles = await Promise.all(
       updates.vehicleIds.map((id) => ctx.db.get(id)),
     );
-    const validVehicles = vehicles.filter((v) => v !== null);
+    const validVehicles = vehicles.filter(
+      (vehicle): vehicle is NonNullable<typeof vehicle> => vehicle !== null,
+    );
+    if (validVehicles.length !== updates.vehicleIds.length) {
+      throw new Error("One or more vehicles not found");
+    }
+    const petFeeVehicleIds = updates.petFeeVehicleIds ?? existingAppointment.petFeeVehicleIds ?? [];
+    const selectedVehicleIdSet = new Set(updates.vehicleIds);
+    if (petFeeVehicleIds.some((vehicleId) => !selectedVehicleIdSet.has(vehicleId))) {
+      throw new ConvexError({
+        code: "SERVICE_NOT_BOOKABLE",
+        message: "Pet fee vehicles must be included in this appointment.",
+      });
+    }
     const vehicleSize = validVehicles[0]?.size || "medium";
 
-    const totalPrice =
-      validServices.reduce((sum, service) => {
-        return sum + getEffectiveServicePrice(service!, vehicleSize);
-      }, 0) * updates.vehicleIds.length;
+    const serviceItems = validServices.map((service) => {
+      const unitPrice = getEffectiveServicePrice(service!, vehicleSize);
+      return {
+        itemType: "service" as const,
+        serviceId: service!._id,
+        serviceName: service!.name,
+        quantity: updates.vehicleIds.length,
+        unitPrice,
+        totalPrice: unitPrice * updates.vehicleIds.length,
+      };
+    });
+    const petFeeItems = await buildPetFeeItems(ctx, validVehicles, petFeeVehicleIds);
+    const items = [...serviceItems, ...petFeeItems];
+    const totalPrice = items.reduce((sum, item) => sum + item.totalPrice, 0);
     const duration = validServices.reduce(
       (sum, service) => sum + (service!.duration || 0),
       0,
@@ -727,6 +796,7 @@ export const update = mutation({
       },
       totalPrice,
       notes: updates.notes,
+      petFeeVehicleIds,
     });
 
     const invoice = await ctx.db
@@ -735,17 +805,6 @@ export const update = mutation({
       .unique();
 
     if (invoice) {
-      const items = validServices.map((service) => {
-        const unitPrice = getEffectiveServicePrice(service!, vehicleSize);
-        return {
-          serviceId: service!._id,
-          serviceName: service!.name,
-          quantity: updates.vehicleIds.length,
-          unitPrice,
-          totalPrice: unitPrice * updates.vehicleIds.length,
-        };
-      });
-
       const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0);
       const total = subtotal + invoice.tax;
       const depositAmount = invoice.depositAmount || 0;

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -18,6 +18,7 @@ import {
   normalizeUserNotificationPreferences,
 } from "./lib/notificationSettings";
 import {
+  getEffectivePetFeePrice,
   getEffectiveServicePrice,
   type VehicleSize,
 } from "./lib/pricing";
@@ -42,6 +43,7 @@ const draftVehicleValidator = v.object({
   ),
   color: v.optional(v.string()),
   licensePlate: v.optional(v.string()),
+  hasPet: v.optional(v.boolean()),
 });
 
 const bookingPaymentOptionValidator = v.union(
@@ -87,6 +89,12 @@ function getVehicleSizeForDraft(args: {
     return "medium";
   }
   return "small";
+}
+
+function formatVehicleSizeLabel(size: VehicleSize) {
+  if (size === "small") return "Small";
+  if (size === "large") return "Large";
+  return "Medium";
 }
 
 function assertBookableServices(
@@ -199,6 +207,12 @@ async function buildDraftPricing(args: {
   serviceIds: Id<"services">[];
   vehicleCount: number;
   vehicleSize: VehicleSize;
+  existingVehicles: Array<Doc<"vehicles">>;
+  draftVehicles: Array<{
+    size?: VehicleSize;
+    hasPet?: boolean;
+  }>;
+  petFeeExistingVehicleIds: Id<"vehicles">[];
 }) {
   const services = await getServicesForDraft(args.ctx, args.serviceIds);
   assertBookableServices(services, args.serviceIds, args.vehicleSize);
@@ -207,6 +221,7 @@ async function buildDraftPricing(args: {
     const unitPrice = getEffectiveServicePrice(service, args.vehicleSize);
 
     return {
+      itemType: "service" as const,
       serviceId: service._id,
       serviceName: service.name,
       quantity: args.vehicleCount,
@@ -215,7 +230,36 @@ async function buildDraftPricing(args: {
     };
   });
 
-  const totalPrice = items.reduce((sum, item) => sum + item.totalPrice, 0);
+  const petFeeSettings = await args.ctx.runQuery(
+    internal.petFeeSettings.getInternal,
+    {},
+  );
+  const petFeeVehicleIdSet = new Set(args.petFeeExistingVehicleIds);
+  const petFeeSizes = [
+    ...args.existingVehicles
+      .filter((vehicle) => petFeeVehicleIdSet.has(vehicle._id))
+      .map((vehicle) => vehicle.size ?? "medium"),
+    ...args.draftVehicles
+      .filter((vehicle) => vehicle.hasPet)
+      .map((vehicle) => vehicle.size ?? "medium"),
+  ];
+  const petFeeItems = (["small", "medium", "large"] as VehicleSize[])
+    .map((size) => {
+      const quantity = petFeeSizes.filter((petFeeSize) => petFeeSize === size).length;
+      const unitPrice = getEffectivePetFeePrice(petFeeSettings, size);
+      return {
+        itemType: "pet_fee" as const,
+        serviceName: `Pet fee - ${formatVehicleSizeLabel(size)} vehicle`,
+        quantity,
+        unitPrice,
+        totalPrice: unitPrice * quantity,
+      };
+    })
+    .filter((item) => item.quantity > 0 && item.totalPrice > 0);
+
+  const priceItems = [...items, ...petFeeItems];
+
+  const totalPrice = priceItems.reduce((sum, item) => sum + item.totalPrice, 0);
   const duration = services.reduce((sum, service) => sum + (service.duration || 0), 0);
   const depositSettings = await args.ctx.runQuery(
     internal.depositSettings.getInternal,
@@ -227,7 +271,7 @@ async function buildDraftPricing(args: {
 
   return {
     services,
-    items,
+    items: priceItems,
     totalPrice,
     duration,
     depositAmount,
@@ -251,6 +295,7 @@ export const createOrUpdate = mutation({
     address: addressValidator,
     existingVehicleIds: v.optional(v.array(v.id("vehicles"))),
     vehicles: v.optional(v.array(draftVehicleValidator)),
+    petFeeExistingVehicleIds: v.optional(v.array(v.id("vehicles"))),
     serviceIds: v.array(v.id("services")),
     scheduledDate: v.string(),
     scheduledTime: v.string(),
@@ -266,6 +311,7 @@ export const createOrUpdate = mutation({
     const scheduledDate = normalizeDateKey(args.scheduledDate);
     const existingVehicleIds = args.existingVehicleIds ?? [];
     const draftVehicles = args.vehicles ?? [];
+    const petFeeExistingVehicleIds = args.petFeeExistingVehicleIds ?? [];
 
     if (existingVehicleIds.length === 0 && draftVehicles.length === 0) {
       throw new ConvexError({
@@ -304,6 +350,14 @@ export const createOrUpdate = mutation({
       });
     }
 
+    const existingVehicleIdSet = new Set(existingVehicleIds);
+    if (petFeeExistingVehicleIds.some((vehicleId) => !existingVehicleIdSet.has(vehicleId))) {
+      throw new ConvexError({
+        code: "SERVICE_NOT_BOOKABLE",
+        message: "Pet fee vehicles must be included in this booking.",
+      });
+    }
+
     const vehicleCount = existingVehicleIds.length + draftVehicles.length;
     const vehicleSize = getVehicleSizeForDraft({
       existingVehicles: validExistingVehicles,
@@ -339,6 +393,9 @@ export const createOrUpdate = mutation({
       serviceIds: args.serviceIds,
       vehicleCount,
       vehicleSize,
+      existingVehicles: validExistingVehicles,
+      draftVehicles,
+      petFeeExistingVehicleIds,
     });
 
     if (existingDraft) {
@@ -352,6 +409,7 @@ export const createOrUpdate = mutation({
         address: args.address,
         existingVehicleIds,
         draftVehicles,
+        petFeeExistingVehicleIds,
         serviceIds: args.serviceIds,
         scheduledDate,
         scheduledTime: args.scheduledTime,
@@ -398,6 +456,7 @@ export const createOrUpdate = mutation({
       address: args.address,
       existingVehicleIds,
       draftVehicles,
+      petFeeExistingVehicleIds,
       serviceIds: args.serviceIds,
       scheduledDate,
       scheduledTime: args.scheduledTime,
@@ -678,6 +737,7 @@ export const convertSuccessfulCheckout = internalMutation({
     }
 
     const createdVehicleIds: Id<"vehicles">[] = [];
+    const createdPetFeeVehicleIds: Id<"vehicles">[] = [];
     for (const draftVehicle of draft.draftVehicles) {
       const vehicleId = await ctx.db.insert("vehicles", {
         userId: user._id,
@@ -689,6 +749,9 @@ export const convertSuccessfulCheckout = internalMutation({
         licensePlate: draftVehicle.licensePlate,
       });
       createdVehicleIds.push(vehicleId);
+      if (draftVehicle.hasPet) {
+        createdPetFeeVehicleIds.push(vehicleId);
+      }
     }
 
     const existingVehicles = await Promise.all(
@@ -711,6 +774,13 @@ export const convertSuccessfulCheckout = internalMutation({
     if (vehicleIds.length === 0) {
       throw new Error("Bookings require at least one vehicle.");
     }
+    const validExistingPetFeeVehicleIds = validExistingVehicleIds.filter((vehicleId) =>
+      (draft.petFeeExistingVehicleIds ?? []).includes(vehicleId),
+    );
+    const petFeeVehicleIds = [
+      ...validExistingPetFeeVehicleIds,
+      ...createdPetFeeVehicleIds,
+    ];
 
     const appointmentId = await ctx.db.insert("appointments", {
       userId: user._id,
@@ -731,6 +801,7 @@ export const convertSuccessfulCheckout = internalMutation({
       notes: "Created via checkout conversion",
       createdBy: user._id,
       paymentOption: draft.paymentOption,
+      petFeeVehicleIds,
     });
 
     const invoiceCountResult: { count: number } = await ctx.runQuery(
@@ -817,8 +888,10 @@ export const getPublicContext = query({
         color: vehicle.color,
         licensePlate: vehicle.licensePlate,
         size: vehicle.size,
+        hasPet: vehicle.hasPet ?? false,
       })),
       existingVehicleIds: draft.existingVehicleIds,
+      petFeeExistingVehicleIds: draft.petFeeExistingVehicleIds ?? [],
       paymentOption: draft.paymentOption,
       convertedAppointmentId: draft.convertedAppointmentId,
       convertedInvoiceId: draft.convertedInvoiceId,

--- a/convex/invoices.ts
+++ b/convex/invoices.ts
@@ -28,7 +28,8 @@ const invoiceCreateArgs = {
   invoiceNumber: v.string(),
   items: v.array(
     v.object({
-      serviceId: v.id("services"),
+      itemType: v.optional(v.union(v.literal("service"), v.literal("pet_fee"))),
+      serviceId: v.optional(v.id("services")),
       serviceName: v.string(),
       quantity: v.number(),
       unitPrice: v.number(),

--- a/convex/lib/pricing.ts
+++ b/convex/lib/pricing.ts
@@ -1,5 +1,6 @@
 export type ServiceType = "standard" | "addon" | "subscription";
 export type VehicleSize = "small" | "medium" | "large";
+export const DEFAULT_PET_FEE_AMOUNT = 50;
 
 type ServicePricingShape = {
   basePrice?: number;
@@ -9,6 +10,13 @@ type ServicePricingShape = {
   isActive?: boolean;
   serviceType?: ServiceType;
 };
+
+type PetFeePricingShape = {
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+  basePriceLarge?: number;
+  isActive?: boolean;
+} | null;
 
 export function normalizeServiceType(serviceType?: ServiceType): ServiceType {
   return serviceType ?? "standard";
@@ -43,4 +51,22 @@ export function isBookableStandardService(service: ServicePricingShape): boolean
     normalizeServiceType(service.serviceType) === "standard" &&
     hasAnyPositiveServicePrice(service)
   );
+}
+
+export function getEffectivePetFeePrice(
+  settings: PetFeePricingShape,
+  vehicleSize: VehicleSize,
+): number {
+  if (settings?.isActive === false) {
+    return 0;
+  }
+
+  const fallback = DEFAULT_PET_FEE_AMOUNT;
+  if (vehicleSize === "small") {
+    return settings?.basePriceSmall ?? settings?.basePriceMedium ?? fallback;
+  }
+  if (vehicleSize === "large") {
+    return settings?.basePriceLarge ?? settings?.basePriceMedium ?? fallback;
+  }
+  return settings?.basePriceMedium ?? fallback;
 }

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -423,6 +423,165 @@ describe("payments", () => {
     );
   });
 
+  test("booking draft uses default pet fee when no setting exists", async () => {
+    const t = convexTest(schema, modules);
+    await seedBookingSetup(t, {
+      includeBookableService: false,
+      includeDepositSettings: false,
+    });
+
+    const serviceId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("services", {
+        name: "Default Pet Fee Service",
+        description: "Service with default pet fee",
+        basePrice: 120,
+        basePriceMedium: 120,
+        duration: 60,
+        serviceType: "standard",
+        isActive: true,
+      });
+    });
+
+    const booking = await t.mutation(api.bookingDrafts.createOrUpdate, {
+      name: "Guest Booker",
+      email: "pet-default@example.com",
+      phone: "555-3030",
+      address: {
+        street: "123 Guest St",
+        city: "Springfield",
+        state: "IL",
+        zip: "62701",
+      },
+      vehicles: [
+        {
+          year: 2021,
+          make: "Honda",
+          model: "Civic",
+          size: "medium",
+          hasPet: true,
+        },
+      ],
+      serviceIds: [serviceId],
+      scheduledDate: "2024-12-02",
+      scheduledTime: "10:00",
+    });
+
+    const draft = await t.run(async (ctx: any) => {
+      return await ctx.db.get(booking.draftId);
+    });
+
+    expect(draft).toMatchObject({
+      totalPrice: 170,
+      depositAmount: 50,
+      remainingBalance: 120,
+    });
+    expect(draft?.priceSnapshot).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "pet_fee",
+          serviceName: "Pet fee - Medium vehicle",
+          quantity: 1,
+          unitPrice: 50,
+          totalPrice: 50,
+        }),
+      ]),
+    );
+  });
+
+  test("checkout conversion preserves mixed-size pet fee invoice items", async () => {
+    const t = convexTest(schema, modules);
+    await seedBookingSetup(t, {
+      includeBookableService: false,
+      includeDepositSettings: true,
+    });
+
+    const serviceId = await t.run(async (ctx: any) => {
+      await ctx.db.insert("petFeeSettings", {
+        basePriceSmall: 20,
+        basePriceMedium: 50,
+        basePriceLarge: 80,
+        isActive: true,
+      });
+      return await ctx.db.insert("services", {
+        name: "Mixed Pet Fee Service",
+        description: "Service with mixed pet fees",
+        basePrice: 100,
+        basePriceSmall: 100,
+        basePriceMedium: 100,
+        basePriceLarge: 100,
+        duration: 60,
+        serviceType: "standard",
+        isActive: true,
+      });
+    });
+
+    const booking = await t.mutation(api.bookingDrafts.createOrUpdate, {
+      name: "Mixed Pet Booker",
+      email: "mixed-pet@example.com",
+      phone: "555-4040",
+      address: {
+        street: "456 Guest St",
+        city: "Springfield",
+        state: "IL",
+        zip: "62701",
+      },
+      vehicles: [
+        {
+          year: 2020,
+          make: "Toyota",
+          model: "Corolla",
+          size: "small",
+          hasPet: true,
+        },
+        {
+          year: 2023,
+          make: "Ford",
+          model: "F-150",
+          size: "large",
+          hasPet: true,
+        },
+      ],
+      serviceIds: [serviceId],
+      scheduledDate: "2024-12-02",
+      scheduledTime: "10:00",
+    });
+
+    const converted = await t.mutation(internal.bookingDrafts.convertSuccessfulCheckout, {
+      draftId: booking.draftId,
+      stripeCustomerId: "cus_pet_fee",
+      paymentIntentId: "pi_pet_fee",
+    });
+
+    const result = await t.run(async (ctx: any) => {
+      const appointment = converted
+        ? await ctx.db.get(converted.appointmentId)
+        : null;
+      const invoice = converted
+        ? await ctx.db.get(converted.invoiceId)
+        : null;
+      return { appointment, invoice };
+    });
+
+    expect(converted?.total).toBe(300);
+    expect(result.appointment?.petFeeVehicleIds).toHaveLength(2);
+    expect(result.invoice?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "pet_fee",
+          serviceName: "Pet fee - Small vehicle",
+          unitPrice: 20,
+          totalPrice: 20,
+        }),
+        expect.objectContaining({
+          itemType: "pet_fee",
+          serviceName: "Pet fee - Large vehicle",
+          unitPrice: 80,
+          totalPrice: 80,
+        }),
+      ]),
+    );
+  });
+
   test("handle webhook - checkout.session.completed for deposit", async () => {
     const t = convexTest(schema, modules);
     const userId = await createTestUser(t);

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -2322,14 +2322,21 @@ async function createCheckoutSessionForDraft(
   };
 
   let depositPriceId: string | undefined;
+  let depositPerVehicle = 50;
   try {
     const depositSettings = await ctx.runQuery(api.depositSettings.get, {});
     depositPriceId = depositSettings?.stripePriceId;
+    depositPerVehicle = depositSettings?.amountPerVehicle ?? depositPerVehicle;
   } catch (error) {
     console.warn("Could not fetch deposit settings:", error);
   }
 
   const vehicleCount = draft.vehicleCount;
+  const expectedDepositFromPrice = depositPerVehicle * vehicleCount;
+  const canUseDepositPriceId =
+    depositPriceId &&
+    Math.round(draft.depositAmount * 100) ===
+      Math.round(expectedDepositFromPrice * 100);
   let sessionId = "";
   let url = "";
 
@@ -2368,9 +2375,9 @@ async function createCheckoutSessionForDraft(
     });
     sessionId = session.id;
     url = session.url;
-  } else if (depositPriceId) {
+  } else if (canUseDepositPriceId) {
     const session = await stripeClient.createCheckoutSession(ctx, {
-      priceId: depositPriceId,
+      priceId: depositPriceId!,
       customerId: stripeCustomerId,
       mode: "payment",
       successUrl,

--- a/convex/petFeeSettings.ts
+++ b/convex/petFeeSettings.ts
@@ -1,0 +1,57 @@
+import { query, mutation, internalQuery } from "./_generated/server";
+import { v } from "convex/values";
+import { requireAdmin } from "./auth";
+import { DEFAULT_PET_FEE_AMOUNT } from "./lib/pricing";
+
+const petFeeSettingsValidator = v.object({
+  basePriceSmall: v.number(),
+  basePriceMedium: v.number(),
+  basePriceLarge: v.number(),
+  isActive: v.boolean(),
+});
+
+const defaultPetFeeSettings = {
+  basePriceSmall: DEFAULT_PET_FEE_AMOUNT,
+  basePriceMedium: DEFAULT_PET_FEE_AMOUNT,
+  basePriceLarge: DEFAULT_PET_FEE_AMOUNT,
+  isActive: true,
+};
+
+export const get = query({
+  args: {},
+  returns: petFeeSettingsValidator,
+  handler: async (ctx) => {
+    const settings = await ctx.db.query("petFeeSettings").first();
+    return settings ?? defaultPetFeeSettings;
+  },
+});
+
+export const getInternal = internalQuery({
+  args: {},
+  returns: petFeeSettingsValidator,
+  handler: async (ctx) => {
+    const settings = await ctx.db.query("petFeeSettings").first();
+    return settings ?? defaultPetFeeSettings;
+  },
+});
+
+export const upsert = mutation({
+  args: {
+    basePriceSmall: v.number(),
+    basePriceMedium: v.number(),
+    basePriceLarge: v.number(),
+    isActive: v.boolean(),
+  },
+  returns: v.id("petFeeSettings"),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const existing = await ctx.db.query("petFeeSettings").first();
+    if (existing) {
+      await ctx.db.patch(existing._id, args);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("petFeeSettings", args);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -94,6 +94,14 @@ const schema = defineSchema({
     isActive: v.boolean(),
   }),
 
+  // Pet Fee Settings
+  petFeeSettings: defineTable({
+    basePriceSmall: v.number(),
+    basePriceMedium: v.number(),
+    basePriceLarge: v.number(),
+    isActive: v.boolean(),
+  }),
+
   // Services and Subscriptions
   services: defineTable({
     name: v.string(),
@@ -164,6 +172,7 @@ const schema = defineSchema({
       ),
     ),
     subscriptionId: v.optional(v.id("subscriptions")),
+    petFeeVehicleIds: v.optional(v.array(v.id("vehicles"))),
   })
     .index("by_user", ["userId"])
     .index("by_date", ["scheduledDate"])
@@ -193,8 +202,10 @@ const schema = defineSchema({
         ),
         color: v.optional(v.string()),
         licensePlate: v.optional(v.string()),
+        hasPet: v.optional(v.boolean()),
       }),
     ),
+    petFeeExistingVehicleIds: v.optional(v.array(v.id("vehicles"))),
     serviceIds: v.array(v.id("services")),
     scheduledDate: v.string(),
     scheduledTime: v.string(),
@@ -215,7 +226,8 @@ const schema = defineSchema({
     ),
     priceSnapshot: v.array(
       v.object({
-        serviceId: v.id("services"),
+        itemType: v.optional(v.union(v.literal("service"), v.literal("pet_fee"))),
+        serviceId: v.optional(v.id("services")),
         serviceName: v.string(),
         quantity: v.number(),
         unitPrice: v.number(),
@@ -272,7 +284,8 @@ const schema = defineSchema({
     invoiceNumber: v.string(),
     items: v.array(
       v.object({
-        serviceId: v.id("services"),
+        itemType: v.optional(v.union(v.literal("service"), v.literal("pet_fee"))),
+        serviceId: v.optional(v.id("services")),
         serviceName: v.string(),
         quantity: v.number(),
         unitPrice: v.number(),

--- a/hooks/use-booking-store.ts
+++ b/hooks/use-booking-store.ts
@@ -11,6 +11,7 @@ interface Vehicle {
   licensePlate?: string
   size?: "small" | "medium" | "large"
   type?: string // Optional type on individual vehicle if needed, but step3Data has global vehicleType
+  hasPet?: boolean
 }
 
 interface Step1Data {


### PR DESCRIPTION
## Summary
- Add admin-managed pet fee settings with small, medium, and large prices defaulting to 
- Collect per-vehicle pet fee selections in public booking, dashboard booking, and admin appointment flows
- Include pet fee lines in booking drafts, appointments, invoices, checkout totals, and conversion tests

## Implementation Notes
- Added a dedicated petFeeSettings Convex module and schema table
- Extended booking draft and appointment records with pet-fee vehicle selections
- Invoice line items now support service and pet fee item types while preserving legacy service item shape
- Deposit checkout now falls back to dynamic capped pricing when a saved Stripe deposit price would not match the calculated draft deposit

## Testing Notes
- pnpm check: unavailable, script not defined
- pnpm typecheck: unavailable, script not defined
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build

Project note: gh project list cannot run because the current GitHub token is missing read:project scope.

Closes #24