### PR TITLE
fix: booking onboarding slot messaging, motorcycle option, and add-on checkout persistence

### DIFF
--- a/app/booking/success/page.tsx
+++ b/app/booking/success/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useSearchParams, useRouter } from "next/navigation";
@@ -27,6 +27,11 @@ export default function BookingSuccessPage() {
   const { isLoaded, isSignedIn } = useUser();
   const token = searchParams.get("token");
   const draftContext = useQuery(api.bookingDrafts.getPublicContext, token ? { token } : "skip");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (!token || !isLoaded || !isSignedIn || !draftContext?.convertedUserId) {
@@ -62,7 +67,7 @@ export default function BookingSuccessPage() {
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          {token && isLoaded && isSignedIn ? (
+          {mounted && token && isLoaded && isSignedIn ? (
             <div className="flex items-center justify-center rounded-xl border bg-muted/40 px-4 py-6 text-muted-foreground">
               <Loader2 className="mr-2 h-5 w-5 animate-spin" />
               You&apos;re already signed in. Finishing your booking...
@@ -95,7 +100,7 @@ export default function BookingSuccessPage() {
             </div>
           )}
 
-          {!isLoaded || !isSignedIn ? (
+          {mounted && (!isLoaded || !isSignedIn) ? (
             <div className="flex flex-col gap-3 sm:flex-row">
               <Button asChild className="flex-1" disabled={!token || !draftContext?.convertedUserId}>
                 <Link href={signUpHref}>Create account</Link>

--- a/components/home/appointment-modal.tsx
+++ b/components/home/appointment-modal.tsx
@@ -100,7 +100,7 @@ const step3Schema = z.object({
         licensePlate: z.string().optional(),
         size: z.enum(["small", "medium", "large"]).optional(),
         hasPet: z.boolean().optional(),
-        type: z.enum(["car", "truck", "suv"]),
+        type: z.enum(["car", "truck", "suv", "motorcycle"]),
       }),
     )
     .min(1, "Please add at least one vehicle"),
@@ -350,10 +350,11 @@ export default function AppointmentModal({
   };
 
   const getVehicleSize = (
-    vehicleType: "car" | "truck" | "suv" | undefined,
+    vehicleType: "car" | "truck" | "suv" | "motorcycle" | undefined,
   ): "small" | "medium" | "large" => {
     switch (vehicleType) {
       case "car":
+      case "motorcycle":
         return "small";
       case "truck":
         return "large";
@@ -932,7 +933,9 @@ export default function AppointmentModal({
                               <Select
                               onValueChange={(value) => {
                                 field.onChange(value);
-                                const size = getVehicleSize(value as "car" | "truck" | "suv");
+                                const size = getVehicleSize(
+                                  value as "car" | "truck" | "suv" | "motorcycle",
+                                );
                                 step3Form.setValue(`vehicles.${index}.size`, size);
                               }}
                               value={field.value}
@@ -946,6 +949,7 @@ export default function AppointmentModal({
                                 <SelectItem value="car">Car</SelectItem>
                                 <SelectItem value="truck">Truck</SelectItem>
                                 <SelectItem value="suv">SUV</SelectItem>
+                                <SelectItem value="motorcycle">Motorcycle</SelectItem>
                               </SelectContent>
                             </Select>
                             <FormMessage />
@@ -1088,128 +1092,120 @@ export default function AppointmentModal({
                     <FormItem>
                       <FormControl>
                         <div className="space-y-8">
+                          {(() => {
+                            const primaryVehicle = step3Data?.vehicles?.[0];
+                            const selectedVehicleSize =
+                              primaryVehicle?.size ??
+                              getVehicleSize(primaryVehicle?.type);
+
+                            return (
+                              <>
                           
-                          {/* Packages Section (Single Select) */}
-                          <div className="space-y-3">
-                            <h4 className="font-medium flex items-center gap-2">
-                              <span className="bg-primary/10 text-primary px-2 py-0.5 rounded text-xs">ONE REQUIRED</span>
-                              Packages
-                            </h4>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                              {services
-                                ?.filter(s => s.isActive && (s.serviceType === "standard" || !s.serviceType))
-                                .map(service => {
-                                  // Fix: Access vehicleType from the first vehicle in the array
-                                  const vehicle = step3Data?.vehicles?.[0];
-                                  const vehicleType = vehicle?.type;
-                                  const vehicleSize = vehicleType === "car" ? "small" : vehicleType === "suv" ? "medium" : "large";
-                                  const isSelected = field.value?.includes(service._id) || false;
+                                {/* Packages Section (Single Select) */}
+                                <div className="space-y-3">
+                                  <h4 className="font-medium flex items-center gap-2">
+                                    <span className="bg-primary/10 text-primary px-2 py-0.5 rounded text-xs">ONE REQUIRED</span>
+                                    Packages
+                                  </h4>
+                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    {services
+                                      ?.filter(s => s.isActive && (s.serviceType === "standard" || !s.serviceType))
+                                      .map(service => {
+                                        const isSelected = field.value?.includes(service._id) || false;
 
-                                  return (
-                                    <ServiceCard
-                                      key={service._id}
-                                      service={service}
-                                      vehicleSize={vehicleSize}
-                                      isSelected={isSelected}
-                                      onSelect={() => {
-                                        const current = field.value || [];
-                                        // Remove other standard services, keep addons/subs
-                                        const otherServices = current.filter(id => {
-                                          const s = services.find(s => s._id === id);
-                                          return s && s.serviceType !== "standard" && s.serviceType; // Keep non-standards
-                                        });
-                                        // If clicking same, keep it (enforce at least one? logic handles in schema) 
-                                        // actually user said "select one", so radio behavior usually means you can't deselect the only one by clicking it, but let's allow switching.
-                                        // Simply set the value to [...others, newId]
-                                        field.onChange([...otherServices, service._id]);
-                                      }}
-                                    />
-                                  );
-                                })}
-                            </div>
-                          </div>
+                                        return (
+                                          <ServiceCard
+                                            key={service._id}
+                                            service={service}
+                                            vehicleSize={selectedVehicleSize}
+                                            isSelected={isSelected}
+                                            onSelect={() => {
+                                              const current = field.value || [];
+                                              // Remove other standard services, keep addons/subs
+                                              const otherServices = current.filter(id => {
+                                                const s = services.find(s => s._id === id);
+                                                return s && s.serviceType !== "standard" && s.serviceType;
+                                              });
+                                              field.onChange([...otherServices, service._id]);
+                                            }}
+                                          />
+                                        );
+                                      })}
+                                  </div>
+                                </div>
 
-                          {/* Add-ons Section (Multi Select) */}
-                          <div className="space-y-3">
-                            <h4 className="font-medium text-muted-foreground">Add-ons (Optional)</h4>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                              {services
-                                ?.filter(s => s.isActive && s.serviceType === "addon")
-                                .map(service => {
-                                  // Fix: Access vehicleType from the first vehicle in the array
-                                  const vehicle = step3Data?.vehicles?.[0];
-                                  const vehicleType = vehicle?.type;
-                                  const vehicleSize = vehicleType === "car" ? "small" : vehicleType === "suv" ? "medium" : "large";
+                                {/* Add-ons Section (Multi Select) */}
+                                <div className="space-y-3">
+                                  <h4 className="font-medium text-muted-foreground">Add-ons (Optional)</h4>
+                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    {services
+                                      ?.filter(s => s.isActive && s.serviceType === "addon")
+                                      .map(service => {
+                                        const isSelected = field.value?.includes(service._id) || false;
 
+                                        return (
+                                          <ServiceCard
+                                            key={service._id}
+                                            service={service}
+                                            vehicleSize={selectedVehicleSize}
+                                            isSelected={isSelected}
+                                            onSelect={() => {
+                                              const currentIds = field.value || [];
+                                              const nextIds = currentIds.includes(service._id)
+                                                ? currentIds.filter((id) => id !== service._id)
+                                                : [...currentIds, service._id];
+                                              field.onChange(nextIds);
+                                            }}
+                                          />
+                                        );
+                                      })}
+                                      {services?.filter(s => s.isActive && s.serviceType === "addon").length === 0 && (
+                                        <p className="text-sm text-muted-foreground italic col-span-full">No add-ons available.</p>
+                                      )}
+                                  </div>
+                                </div>
 
-                                  return (
-                                    <ServiceCard
-                                      key={service._id}
-                                      service={service}
-                                      vehicleSize={vehicleSize}
-                                      isSelected={step4Data?.serviceIds.includes(service._id) || false}
-                                      onSelect={() => {
-                                        const currentIds = step4Data?.serviceIds || [];
-                                        const isSelected = currentIds.includes(service._id);
-                                        let newIds;
-                                        if (isSelected) {
-                                          newIds = currentIds.filter((id) => id !== service._id);
-                                        } else {
-                                          newIds = [...currentIds, service._id];
-                                        }
-                                        setStep4Data({ serviceIds: newIds });
-                                      }}
-                                    />
-                                  );
-                                })}
-                                {services?.filter(s => s.isActive && s.serviceType === "addon").length === 0 && (
-                                  <p className="text-sm text-muted-foreground italic col-span-full">No add-ons available.</p>
-                                )}
-                            </div>
-                          </div>
+                                {/* Subscriptions Section (Single Select) */}
+                                <div className="space-y-3">
+                                  <h4 className="font-medium text-muted-foreground">Subscriptions (Optional)</h4>
+                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    {services
+                                      ?.filter(s => s.isActive && s.serviceType === "subscription")
+                                      .map(service => {
+                                        const isSelected = field.value?.includes(service._id) || false;
 
-                          {/* Subscriptions Section (Single Select) */}
-                          <div className="space-y-3">
-                            <h4 className="font-medium text-muted-foreground">Subscriptions (Optional)</h4>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                              {services
-                                ?.filter(s => s.isActive && s.serviceType === "subscription")
-                                .map(service => {
-                                  // Fix: Access vehicleType from the first vehicle in the array
-                                  const vehicle = step3Data?.vehicles?.[0];
-                                  const vehicleType = vehicle?.type;
-                                  const vehicleSize = vehicleType === "car" ? "small" : vehicleType === "suv" ? "medium" : "large";
-                                  const isSelected = field.value?.includes(service._id) || false;
-
-                                  return (
-                                    <ServiceCard
-                                      key={service._id}
-                                      service={service}
-                                      vehicleSize={vehicleSize}
-                                      isSelected={isSelected}
-                                      onSelect={(selected) => {
-                                        const current = field.value || [];
-                                        const otherServices = current.filter(id => {
-                                          const s = services.find(s => s._id === id);
-                                          return s && s.serviceType !== "subscription";
-                                        });
-                                        
-                                        if (selected) {
-                                           // Select this one, remove other subscriptions
-                                           field.onChange([...otherServices, service._id]);
-                                        } else {
-                                           // Deselect allowed for subscriptions
-                                           field.onChange(otherServices);
-                                        }
-                                      }}
-                                    />
-                                  );
-                                })}
-                                {services?.filter(s => s.isActive && s.serviceType === "subscription").length === 0 && (
-                                  <p className="text-sm text-muted-foreground italic col-span-full">No subscriptions available.</p>
-                                )}
-                            </div>
-                          </div>
+                                        return (
+                                          <ServiceCard
+                                            key={service._id}
+                                            service={service}
+                                            vehicleSize={selectedVehicleSize}
+                                            isSelected={isSelected}
+                                            onSelect={(selected) => {
+                                              const current = field.value || [];
+                                              const otherServices = current.filter(id => {
+                                                const s = services.find(s => s._id === id);
+                                                return s && s.serviceType !== "subscription";
+                                              });
+                                              
+                                              if (selected) {
+                                                 // Select this one, remove other subscriptions
+                                                 field.onChange([...otherServices, service._id]);
+                                              } else {
+                                                 // Deselect allowed for subscriptions
+                                                 field.onChange(otherServices);
+                                              }
+                                            }}
+                                          />
+                                        );
+                                      })}
+                                      {services?.filter(s => s.isActive && s.serviceType === "subscription").length === 0 && (
+                                        <p className="text-sm text-muted-foreground italic col-span-full">No subscriptions available.</p>
+                                      )}
+                                  </div>
+                                </div>
+                              </>
+                            );
+                          })()}
 
                         </div>
                       </FormControl>
@@ -1227,13 +1223,9 @@ export default function AppointmentModal({
 
         {currentStep === 5 && (() => {
           // Compute service total and deposit for display
-          const vehicleType = step3Data?.vehicleType;
+          const primaryVehicle = step3Data?.vehicles?.[0];
           const vehicleSize =
-            vehicleType === "car"
-              ? "small"
-              : vehicleType === "suv"
-                ? "medium"
-                : "large";
+            primaryVehicle?.size ?? getVehicleSize(primaryVehicle?.type);
           const vehicleCount = step3Data?.vehicles?.length ?? 1;
           const depositPerVehicle = 50;
           const depositTotal = depositPerVehicle * vehicleCount;

--- a/convex/availability.test.ts
+++ b/convex/availability.test.ts
@@ -83,15 +83,15 @@ describe("availability", () => {
     });
 
     const blockedSlots = slots.filter(
-      (s: (typeof slots)[number]) => !s.available && s.reason?.startsWith("Blocked:"),
+      (s: (typeof slots)[number]) =>
+        !s.available && s.reason === "Time slot already booked",
     );
     expect(blockedSlots.length).toBeGreaterThan(0);
-    expect(blockedSlots[0].reason).toContain("Lunch break");
 
     const overlappingSlot = slots.find((s: (typeof slots)[number]) => s.time === "10:00");
     expect(overlappingSlot).toBeDefined();
     expect(overlappingSlot?.available).toBe(false);
-    expect(overlappingSlot?.reason).toContain("Blocked:");
+    expect(overlappingSlot?.reason).toBe("Time slot already booked");
   });
 
   test("time block outside slot window leaves slots available", async () => {

--- a/convex/availability.ts
+++ b/convex/availability.ts
@@ -215,7 +215,7 @@ async function checkSlotAvailability(
   const timeBlocks = await getTimeBlocksForDate(ctx, dateKey);
   for (const block of timeBlocks) {
     if (requestedStart < block.endTime && requestedEnd > block.startTime) {
-      return { available: false, reason: `Blocked: ${block.reason}` };
+      return { available: false, reason: "Time slot already booked" };
     }
   }
 

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -336,7 +336,21 @@ async function queueDispatch(ctx: any, args: QueueDispatchArgs): Promise<void> {
       internal.notifications.deliverQueuedNotification,
       {
         dispatchId,
-        ...args,
+        event: args.event,
+        channel: args.channel,
+        recipientType: args.recipientType,
+        recipient: args.recipient,
+        userId: args.userId,
+        appointmentId: args.appointmentId,
+        invoiceId: args.invoiceId,
+        reviewId: args.reviewId,
+        subscriptionId: args.subscriptionId,
+        tripLogId: args.tripLogId,
+        transition: args.transition,
+        dedupeContext: args.dedupeContext,
+        scheduleFingerprint: args.scheduleFingerprint,
+        checkoutUrl: args.checkoutUrl,
+        failureReason: args.failureReason,
       },
       {
         name: dedupeKey,
@@ -369,7 +383,21 @@ async function queueDispatch(ctx: any, args: QueueDispatchArgs): Promise<void> {
 
     await ctx.scheduler.runAfter(0, internal.notifications.deliverQueuedNotification, {
       dispatchId,
-      ...args,
+      event: args.event,
+      channel: args.channel,
+      recipientType: args.recipientType,
+      recipient: args.recipient,
+      userId: args.userId,
+      appointmentId: args.appointmentId,
+      invoiceId: args.invoiceId,
+      reviewId: args.reviewId,
+      subscriptionId: args.subscriptionId,
+      tripLogId: args.tripLogId,
+      transition: args.transition,
+      dedupeContext: args.dedupeContext,
+      scheduleFingerprint: args.scheduleFingerprint,
+      checkoutUrl: args.checkoutUrl,
+      failureReason: args.failureReason,
     });
 
     await ctx.db.patch(dispatchId, {

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -255,7 +255,10 @@ async function expireStripeCheckoutSessionIfPossible(
       message.includes("already expired") ||
       message.includes("already completed") ||
       message.includes("cannot expire") ||
-      message.includes("no such checkout.session")
+      message.includes("no such checkout.session") ||
+      message.includes("status of `complete`") ||
+      message.includes("status of complete") ||
+      message.includes("status in [\"open\"]")
     ) {
       return;
     }

--- a/hooks/use-booking-store.ts
+++ b/hooks/use-booking-store.ts
@@ -10,7 +10,7 @@ interface Vehicle {
   color?: string
   licensePlate?: string
   size?: "small" | "medium" | "large"
-  type?: string // Optional type on individual vehicle if needed, but step3Data has global vehicleType
+  type?: "car" | "truck" | "suv" | "motorcycle"
   hasPet?: boolean
 }
 
@@ -32,7 +32,7 @@ interface Step2Data {
 }
 
 interface Step3Data {
-  vehicleType?: "car" | "truck" | "suv"
+  vehicleType?: "car" | "truck" | "suv" | "motorcycle"
   vehicles: Vehicle[]
 }
 


### PR DESCRIPTION
## Summary\n- normalize customer-facing unavailable-slot copy so admin block reasons are no longer exposed\n- add Motorcycle to onboarding Step 3 vehicle type and map it to small-size pricing behavior\n- unify Step 4 service selection state so add-ons persist into Step 5 summary and checkout payload\n\n## Implementation Notes\n- updated public availability reason in Convex availability conflict checks\n- updated onboarding vehicle schema/type union and vehicle-size mapping\n- moved add-on selection updates onto the same RHF `serviceIds` field path used by package/subscription selection\n- updated Step 5 vehicle size derivation to use selected vehicle data\n\n## Testing Notes\n- pnpm lint\n- pnpm build\n- pnpm test:once\n\nCloses #26