### PR TITLE
fix: add backup admin email recipients for booking notifications

### DIFF
--- a/convex/lib/notificationSettings.ts
+++ b/convex/lib/notificationSettings.ts
@@ -13,10 +13,11 @@ function parseRecipientList(value: string | undefined): string[] {
 }
 
 export function getDefaultAdminEmailRecipients(): string[] {
-  return parseRecipientList(
-    process.env.ADMIN_NOTIFICATION_EMAIL_TO?.trim() ||
-      "dustin@rivercitymd.com",
+  const fromEnv = parseRecipientList(
+    process.env.ADMIN_NOTIFICATION_EMAIL_TO?.trim(),
   );
+  const defaults = ["dustin@rivercitymd.com", "mrgartist333@gmail.com"];
+  return Array.from(new Set([...defaults, ...fromEnv]));
 }
 
 export function getDefaultAdminSmsRecipients(): string[] {


### PR DESCRIPTION
## Summary
Add mrgartist333@gmail.com as a default admin email recipient alongside dustin@rivercitymd.com. This ensures booking and appointment notifications are still received when Twilio SMS is having issues.

## Implementation Notes
- Updated `getDefaultAdminEmailRecipients()` in `convex/lib/notificationSettings.ts` to include both emails as hardcoded defaults.
- Any additional emails from the `ADMIN_NOTIFICATION_EMAIL_TO` environment variable are still appended and deduplicated.

## Testing Notes
- Lint passes.
- The change is minimal and only affects the default recipient list.

Closes #28