### PR TITLE
fix: opt GitHub Actions into Node.js 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Run Tests
 
 on: [pull_request, push]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,11 +9,11 @@ jobs:
     env:
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: [pull_request, push]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to River City Mobile Detailing are documented in this file.
 
 ### Changed
 
-- Opted GitHub Actions JavaScript actions into the Node.js 24 runtime.
+- Upgraded checkout, pnpm setup, and Node setup GitHub Actions to Node.js 24-native releases.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to River City Mobile Detailing are documented in this file.
 
+## [0.1.1] - 2026-06-04
+
+### Changed
+
+- Opted GitHub Actions JavaScript actions into the Node.js 24 runtime.
+
+### Fixed
+
+- Removed the GitHub Actions Node.js 20 deprecation warning ahead of the June 16, 2026 default-runtime change.
+
 ## [0.1.0] - 2026-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivercitymd",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",


### PR DESCRIPTION
## Summary

- Upgrade GitHub-hosted JavaScript actions to Node.js 24-native releases.
- Record the workflow maintenance patch as version 0.1.1.

## Implementation Notes

- Updates `actions/checkout` from v4 to v5.
- Updates `actions/setup-node` from v4 to v5.
- Updates `pnpm/action-setup` from v4 to v6.
- Keeps the application test runtime on Node.js 20 because exact Node.js 24 testing exposed a separate Convex authenticated-page prerender compatibility issue tracked in #37.

## Testing Notes

- Workflow YAML parses successfully.
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test:once` - 126 tests passed
- PR CI must pass with no Node.js 20 action annotations before merge.

Closes #36