### PR TITLE
feat: filter booking products by vehicle type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to River City Mobile Detailing are documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Filter booking services, add-ons, and subscriptions by the selected vehicle type across marketing-site and dashboard booking flows.
+- Calculate multi-vehicle booking totals and appointment duration from each selected service per vehicle, including vehicle-type pricing rows and pet-fee time.
+
+### Fixed
+
+- Kept draft checkout duration recalculation aligned with multi-vehicle service duration blocking.
+
 ## [0.1.1] - 2026-06-04
 
 ### Changed

--- a/components/forms/dashboard/dashboard-appointment-form.tsx
+++ b/components/forms/dashboard/dashboard-appointment-form.tsx
@@ -6,7 +6,8 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { formatDateString, formatTime12h } from "@/lib/time";
 import {
-  getEffectiveServicePrice,
+  getEffectiveServicePricingForVehicle,
+  isServiceAvailableForVehicle,
   normalizeServiceType,
 } from "@/convex/lib/pricing";
 import { calculateSchedulingDuration } from "@/convex/lib/booking";
@@ -235,10 +236,18 @@ export function DashboardAppointmentForm({
   );
   const vehicleSize: VehicleSize =
     (selectedVehicle?.size as VehicleSize) || "medium";
+  const vehicleTypeId = selectedVehicle?.vehicleTypeId ?? null;
+  const vehiclePricingContext = useMemo(
+    () => ({ vehicleSize, vehicleTypeId }),
+    [vehicleSize, vehicleTypeId],
+  );
 
   const activeServices = useMemo(
-    () => services?.filter((s) => s.isActive) ?? [],
-    [services],
+    () =>
+      services?.filter((service) =>
+        isServiceAvailableForVehicle(service, vehiclePricingContext),
+      ) ?? [],
+    [services, vehiclePricingContext],
   );
 
   const standardServices = useMemo(
@@ -263,6 +272,27 @@ export function DashboardAppointmentForm({
     [activeServices],
   );
 
+  React.useEffect(() => {
+    if (
+      selectedStandardId &&
+      !standardServices.some((service) => service._id === selectedStandardId)
+    ) {
+      setSelectedStandardId(null);
+    }
+
+    const availableOptionalIds = new Set<string>(
+      [...addonServices, ...subscriptionServices].map((service) => service._id),
+    );
+    setSelectedServiceIds((current) =>
+      current.filter((serviceId) => availableOptionalIds.has(serviceId)),
+    );
+  }, [
+    addonServices,
+    selectedStandardId,
+    standardServices,
+    subscriptionServices,
+  ]);
+
   // All selected service IDs (standard + addons + subscriptions)
   const allSelectedServiceIds = useMemo(() => {
     const ids = [...selectedServiceIds];
@@ -280,10 +310,15 @@ export function DashboardAppointmentForm({
   const serviceTotal = useMemo(
     () =>
       selectedServicesData.reduce(
-        (sum, s) => sum + getEffectiveServicePrice(s, vehicleSize),
+        (sum, service) =>
+          sum +
+          getEffectiveServicePricingForVehicle(
+            service,
+            vehiclePricingContext,
+          ).price,
         0,
       ),
-    [selectedServicesData, vehicleSize],
+    [selectedServicesData, vehiclePricingContext],
   );
 
   const petFeeTotal = useMemo(() => {
@@ -305,7 +340,13 @@ export function DashboardAppointmentForm({
   const schedulingDuration = useMemo(
     () =>
       calculateSchedulingDuration({
-        serviceDurations: selectedServicesData.map((service) => service.duration || 0),
+        serviceDurations: selectedServicesData.map(
+          (service) =>
+            getEffectiveServicePricingForVehicle(
+              service,
+              vehiclePricingContext,
+            ).duration,
+        ),
         petFeeVehicleCount:
           hasPetFee && petFeeSettings?.isActive !== false ? 1 : 0,
         petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
@@ -315,6 +356,7 @@ export function DashboardAppointmentForm({
       petFeeSettings?.isActive,
       petFeeSettings?.timeAddMinutes,
       selectedServicesData,
+      vehiclePricingContext,
     ],
   );
 
@@ -536,6 +578,7 @@ export function DashboardAppointmentForm({
                           key={service._id}
                           service={service}
                           vehicleSize={vehicleSize}
+                          vehicleTypeId={vehicleTypeId}
                           isSelected={selectedStandardId === service._id}
                           onSelect={(selected) =>
                             setSelectedStandardId(
@@ -565,6 +608,7 @@ export function DashboardAppointmentForm({
                           key={service._id}
                           service={service}
                           vehicleSize={vehicleSize}
+                          vehicleTypeId={vehicleTypeId}
                           isSelected={selectedServiceIds.includes(service._id)}
                           onSelect={(selected) =>
                             handleAddonToggle(service._id, selected)
@@ -592,6 +636,7 @@ export function DashboardAppointmentForm({
                           key={service._id}
                           service={service}
                           vehicleSize={vehicleSize}
+                          vehicleTypeId={vehicleTypeId}
                           isSelected={selectedServiceIds.includes(service._id)}
                           onSelect={(selected) =>
                             handleAddonToggle(service._id, selected)
@@ -742,7 +787,10 @@ export function DashboardAppointmentForm({
 
               {/* Services */}
               {selectedServicesData.map((service) => {
-                const price = getEffectiveServicePrice(service, vehicleSize);
+                const price = getEffectiveServicePricingForVehicle(
+                  service,
+                  vehiclePricingContext,
+                ).price;
                 const isSubscription =
                   normalizeServiceType(service.serviceType) === "subscription";
                 return (

--- a/components/home/appointment-modal.tsx
+++ b/components/home/appointment-modal.tsx
@@ -7,6 +7,12 @@ import { useBookingStore } from "@/hooks/use-booking-store";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { calculateSchedulingDuration } from "@/convex/lib/booking";
+import {
+  getEffectiveServicePricingForVehicle,
+  isServiceAvailableForVehicle,
+  normalizeServiceType,
+  type VehicleSize,
+} from "@/convex/lib/pricing";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -200,6 +206,28 @@ export default function AppointmentModal({
   const createBookingCheckout = useAction(api.payments.createBookingCheckout);
   const convex = useConvex();
   const currentUser = useQuery(api.users.getCurrentUser, isSignedIn ? {} : "skip");
+  const vehiclePricingContexts = useMemo(() => {
+    const vehicles = step3Data?.vehicles ?? [];
+    if (vehicles.length === 0) {
+      return [{ vehicleSize: "medium" as VehicleSize, vehicleTypeId: null }];
+    }
+
+    return vehicles.map((vehicle) => ({
+      vehicleSize: (vehicle.size ?? "medium") as VehicleSize,
+      vehicleTypeId: vehicle.vehicleTypeId ?? null,
+    }));
+  }, [step3Data?.vehicles]);
+  const primaryVehiclePricingContext = vehiclePricingContexts[0] ?? {
+    vehicleSize: "medium" as VehicleSize,
+    vehicleTypeId: null,
+  };
+  const isAvailableForBookingVehicles = useCallback(
+    (service: Parameters<typeof isServiceAvailableForVehicle>[0]) =>
+      vehiclePricingContexts.every((vehicle) =>
+        isServiceAvailableForVehicle(service, vehicle),
+      ),
+    [vehiclePricingContexts],
+  );
 
   const watchedStreet = step1Form.watch("street");
   const watchedCity = step1Form.watch("city");
@@ -249,7 +277,12 @@ export default function AppointmentModal({
         : step3Data?.vehicles?.filter((vehicle) => vehicle.hasPet).length ?? 0;
 
     return calculateSchedulingDuration({
-      serviceDurations: selectedServices.map((service) => service.duration || 0),
+      serviceDurations: selectedServices.flatMap((service) =>
+        vehiclePricingContexts.map(
+          (vehicle) =>
+            getEffectiveServicePricingForVehicle(service, vehicle).duration,
+        ),
+      ),
       petFeeVehicleCount,
       petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
     });
@@ -259,6 +292,7 @@ export default function AppointmentModal({
     services,
     step3Data?.vehicles,
     step4Data?.serviceIds,
+    vehiclePricingContexts,
   ]);
 
 
@@ -303,6 +337,35 @@ export default function AppointmentModal({
       serviceIds: step4Data?.serviceIds || [],
     },
   });
+
+  useEffect(() => {
+    if (!services || !step4Data?.serviceIds?.length) {
+      return;
+    }
+
+    const availableServiceIds = new Set(
+      services
+        .filter((service) => isAvailableForBookingVehicles(service))
+        .map((service) => service._id),
+    );
+    const nextServiceIds = step4Data.serviceIds.filter((serviceId) =>
+      availableServiceIds.has(serviceId as Id<"services">),
+    );
+
+    if (nextServiceIds.length !== step4Data.serviceIds.length) {
+      step4Form.setValue("serviceIds", nextServiceIds, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      setStep4Data({ serviceIds: nextServiceIds });
+    }
+  }, [
+    isAvailableForBookingVehicles,
+    services,
+    setStep4Data,
+    step4Data?.serviceIds,
+    step4Form,
+  ]);
 
   // Pre-fill user data if authenticated
   useEffect(() => {
@@ -497,7 +560,13 @@ export default function AppointmentModal({
               ? 0
               : step3Data?.vehicles?.filter((vehicle) => vehicle.hasPet).length ?? 0;
           const selectedDuration = calculateSchedulingDuration({
-            serviceDurations: selectedServices.map((service) => service.duration || 0),
+            serviceDurations: selectedServices.flatMap((service) =>
+              vehiclePricingContexts.map(
+                (vehicle) =>
+                  getEffectiveServicePricingForVehicle(service, vehicle)
+                    .duration,
+              ),
+            ),
             petFeeVehicleCount,
             petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
           });
@@ -1061,8 +1130,31 @@ export default function AppointmentModal({
                       <FormControl>
                         <div className="space-y-8">
                           {(() => {
-                            const primaryVehicle = step3Data?.vehicles?.[0];
-                            const selectedVehicleSize = primaryVehicle?.size ?? "medium";
+                            const selectedVehicleSize =
+                              primaryVehiclePricingContext.vehicleSize;
+                            const selectedVehicleTypeId =
+                              primaryVehiclePricingContext.vehicleTypeId;
+                            const standardServices =
+                              services?.filter(
+                                (service) =>
+                                  normalizeServiceType(service.serviceType) ===
+                                    "standard" &&
+                                  isAvailableForBookingVehicles(service),
+                              ) ?? [];
+                            const addonServices =
+                              services?.filter(
+                                (service) =>
+                                  normalizeServiceType(service.serviceType) ===
+                                    "addon" &&
+                                  isAvailableForBookingVehicles(service),
+                              ) ?? [];
+                            const subscriptionServices =
+                              services?.filter(
+                                (service) =>
+                                  normalizeServiceType(service.serviceType) ===
+                                    "subscription" &&
+                                  isAvailableForBookingVehicles(service),
+                              ) ?? [];
 
                             return (
                               <>
@@ -1074,9 +1166,7 @@ export default function AppointmentModal({
                                     Packages
                                   </h4>
                                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    {services
-                                      ?.filter(s => s.isActive && (s.serviceType === "standard" || !s.serviceType))
-                                      .map(service => {
+                                    {standardServices.map(service => {
                                         const isSelected = field.value?.includes(service._id) || false;
 
                                         return (
@@ -1084,19 +1174,30 @@ export default function AppointmentModal({
                                             key={service._id}
                                             service={service}
                                             vehicleSize={selectedVehicleSize}
+                                            vehicleTypeId={selectedVehicleTypeId}
                                             isSelected={isSelected}
                                             onSelect={() => {
                                               const current = field.value || [];
                                               // Remove other standard services, keep addons/subs
                                               const otherServices = current.filter(id => {
                                                 const s = services.find(s => s._id === id);
-                                                return s && s.serviceType !== "standard" && s.serviceType;
+                                                return (
+                                                  s &&
+                                                  normalizeServiceType(
+                                                    s.serviceType,
+                                                  ) !== "standard"
+                                                );
                                               });
                                               field.onChange([...otherServices, service._id]);
                                             }}
                                           />
                                         );
                                       })}
+                                      {standardServices.length === 0 && (
+                                        <p className="text-sm text-muted-foreground italic col-span-full">
+                                          No packages are available for this vehicle yet.
+                                        </p>
+                                      )}
                                   </div>
                                 </div>
 
@@ -1104,9 +1205,7 @@ export default function AppointmentModal({
                                 <div className="space-y-3">
                                   <h4 className="font-medium text-muted-foreground">Add-ons (Optional)</h4>
                                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    {services
-                                      ?.filter(s => s.isActive && s.serviceType === "addon")
-                                      .map(service => {
+                                    {addonServices.map(service => {
                                         const isSelected = field.value?.includes(service._id) || false;
 
                                         return (
@@ -1114,6 +1213,7 @@ export default function AppointmentModal({
                                             key={service._id}
                                             service={service}
                                             vehicleSize={selectedVehicleSize}
+                                            vehicleTypeId={selectedVehicleTypeId}
                                             isSelected={isSelected}
                                             onSelect={() => {
                                               const currentIds = field.value || [];
@@ -1125,7 +1225,7 @@ export default function AppointmentModal({
                                           />
                                         );
                                       })}
-                                      {services?.filter(s => s.isActive && s.serviceType === "addon").length === 0 && (
+                                      {addonServices.length === 0 && (
                                         <p className="text-sm text-muted-foreground italic col-span-full">No add-ons available.</p>
                                       )}
                                   </div>
@@ -1135,9 +1235,7 @@ export default function AppointmentModal({
                                 <div className="space-y-3">
                                   <h4 className="font-medium text-muted-foreground">Subscriptions (Optional)</h4>
                                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    {services
-                                      ?.filter(s => s.isActive && s.serviceType === "subscription")
-                                      .map(service => {
+                                    {subscriptionServices.map(service => {
                                         const isSelected = field.value?.includes(service._id) || false;
 
                                         return (
@@ -1145,12 +1243,18 @@ export default function AppointmentModal({
                                             key={service._id}
                                             service={service}
                                             vehicleSize={selectedVehicleSize}
+                                            vehicleTypeId={selectedVehicleTypeId}
                                             isSelected={isSelected}
                                             onSelect={(selected) => {
                                               const current = field.value || [];
                                               const otherServices = current.filter(id => {
                                                 const s = services.find(s => s._id === id);
-                                                return s && s.serviceType !== "subscription";
+                                                return (
+                                                  s &&
+                                                  normalizeServiceType(
+                                                    s.serviceType,
+                                                  ) !== "subscription"
+                                                );
                                               });
                                               
                                               if (selected) {
@@ -1164,7 +1268,7 @@ export default function AppointmentModal({
                                           />
                                         );
                                       })}
-                                      {services?.filter(s => s.isActive && s.serviceType === "subscription").length === 0 && (
+                                      {subscriptionServices.length === 0 && (
                                         <p className="text-sm text-muted-foreground italic col-span-full">No subscriptions available.</p>
                                       )}
                                   </div>
@@ -1189,9 +1293,7 @@ export default function AppointmentModal({
 
         {currentStep === 5 && (() => {
           // Compute service total and deposit for display
-          const primaryVehicle = step3Data?.vehicles?.[0];
-          const vehicleSize = primaryVehicle?.size ?? "medium";
-          const vehicleCount = step3Data?.vehicles?.length ?? 1;
+          const vehicleCount = vehiclePricingContexts.length;
           const depositPerVehicle = 50;
           const depositTotal = depositPerVehicle * vehicleCount;
           const petFeeForSize = (size: "small" | "medium" | "large") => {
@@ -1209,14 +1311,14 @@ export default function AppointmentModal({
             step4Data?.serviceIds?.includes(s._id),
           ) ?? [];
           const serviceTotal = selectedServices.reduce((sum, service) => {
-            const price =
-              vehicleSize === "small"
-                ? service.basePriceSmall
-                : vehicleSize === "medium"
-                  ? service.basePriceMedium
-                  : service.basePriceLarge;
-            return sum + (price ?? 0);
-          }, 0) * vehicleCount;
+            const serviceSubtotal = vehiclePricingContexts.reduce(
+              (vehicleSum, vehicle) =>
+                vehicleSum +
+                getEffectiveServicePricingForVehicle(service, vehicle).price,
+              0,
+            );
+            return sum + serviceSubtotal;
+          }, 0);
           const petFeeTotal = (step3Data?.vehicles ?? []).reduce((sum, vehicle) => {
             if (!vehicle.hasPet) return sum;
             return sum + petFeeForSize(vehicle.size ?? "medium");
@@ -1235,12 +1337,13 @@ export default function AppointmentModal({
                </h3>
                {selectedServices.map((service) => {
                    const isSubscription = service.serviceType === "subscription";
-                   const price =
-                     vehicleSize === "small"
-                       ? service.basePriceSmall
-                       : vehicleSize === "medium"
-                         ? service.basePriceMedium
-                         : service.basePriceLarge;
+                   const serviceSubtotal = vehiclePricingContexts.reduce(
+                     (sum, vehicle) =>
+                       sum +
+                       getEffectiveServicePricingForVehicle(service, vehicle)
+                         .price,
+                     0,
+                   );
 
                    return (
                      <div key={service._id} className="flex justify-between text-sm mb-2">
@@ -1249,7 +1352,7 @@ export default function AppointmentModal({
                          {vehicleCount > 1 && <span className="text-xs"> x{vehicleCount}</span>}
                        </span>
                        <div className="flex items-center gap-1">
-                          <span className="font-medium">${((price ?? 0) * vehicleCount).toFixed(2)}</span>
+                          <span className="font-medium">${serviceSubtotal.toFixed(2)}</span>
                           {isSubscription && <span className="text-[10px] text-muted-foreground">/mo</span>}
                        </div>
                      </div>

--- a/components/home/service-card.tsx
+++ b/components/home/service-card.tsx
@@ -3,6 +3,10 @@
 import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import {
+  getEffectiveServicePricingForVehicle,
+  type VehicleSize,
+} from "@/convex/lib/pricing";
 
 interface ServiceCardProps {
   service: {
@@ -12,9 +16,21 @@ interface ServiceCardProps {
     basePriceSmall?: number;
     basePriceMedium?: number;
     basePriceLarge?: number;
+    basePrice?: number;
+    duration?: number;
     serviceType?: "standard" | "addon" | "subscription";
+    vehiclePrices?: Array<{
+      vehicleTypeId?: string;
+      price: number;
+      duration?: number;
+      isAvailable: boolean;
+      vehicleType?: {
+        legacySize?: VehicleSize;
+      } | null;
+    }>;
   };
-  vehicleSize: "small" | "medium" | "large";
+  vehicleSize: VehicleSize;
+  vehicleTypeId?: string | null;
   isSelected: boolean;
   onSelect: (selected: boolean) => void;
 }
@@ -22,16 +38,14 @@ interface ServiceCardProps {
 export function ServiceCard({
   service,
   vehicleSize,
+  vehicleTypeId,
   isSelected,
   onSelect,
 }: ServiceCardProps) {
-  const price =
-    vehicleSize === "small"
-      ? service.basePriceSmall
-      : vehicleSize === "medium"
-        ? service.basePriceMedium
-        : service.basePriceLarge;
-
+  const pricing = getEffectiveServicePricingForVehicle(service, {
+    vehicleSize,
+    vehicleTypeId,
+  });
   const isSubscription = service.serviceType === "subscription";
 
   return (
@@ -72,7 +86,7 @@ export function ServiceCard({
            </div>
            <div className="flex items-baseline gap-1">
              <span className="font-bold text-lg text-primary">
-               ${price?.toFixed(2)}
+               ${pricing.price.toFixed(2)}
              </span>
              {isSubscription && <span className="text-[10px] text-muted-foreground">/mo</span>}
            </div>

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -718,6 +718,36 @@ export const getSchedulingDurationInternal = internalQuery({
         draft.existingVehicleIds.map((vehicleId) => ctx.db.get(vehicleId)),
       )
     ).filter((vehicle): vehicle is Doc<"vehicles"> => vehicle !== null);
+    const pricingVehicles = [
+      ...existingVehicles.map((vehicle) => ({
+        size: vehicle.size,
+        vehicleTypeId: vehicle.vehicleTypeId,
+      })),
+      ...draft.draftVehicles.map((vehicle) => ({
+        size: vehicle.size,
+        vehicleTypeId: vehicle.vehicleTypeId,
+      })),
+    ];
+    const serviceDurations = [];
+    for (const vehicle of pricingVehicles) {
+      for (const service of services) {
+        let serviceDuration = service.duration || 0;
+        if (vehicle.vehicleTypeId) {
+          const matrixPrice = await ctx.db
+            .query("serviceVehiclePrices")
+            .withIndex("by_service_and_vehicle_type", (q: any) =>
+              q
+                .eq("serviceId", service._id)
+                .eq("vehicleTypeId", vehicle.vehicleTypeId),
+            )
+            .first();
+          if (matrixPrice?.isAvailable && matrixPrice.price > 0) {
+            serviceDuration = matrixPrice.duration || serviceDuration;
+          }
+        }
+        serviceDurations.push(serviceDuration);
+      }
+    }
     const petFeeVehicleCount =
       petFeeSettings?.isActive === false
         ? 0
@@ -726,7 +756,7 @@ export const getSchedulingDurationInternal = internalQuery({
           ).length + draft.draftVehicles.filter((vehicle) => vehicle.hasPet).length;
 
     return calculateSchedulingDuration({
-      serviceDurations: services.map((service) => service.duration || 0),
+      serviceDurations,
       petFeeVehicleCount,
       petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
     });

--- a/convex/lib/pricing.test.ts
+++ b/convex/lib/pricing.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+import {
+  getEffectiveServicePricingForVehicle,
+  isServiceAvailableForVehicle,
+} from "./pricing";
+
+describe("vehicle-aware service pricing", () => {
+  test("uses the exact vehicle type price and duration when available", () => {
+    const service = {
+      isActive: true,
+      duration: 60,
+      basePriceSmall: 100,
+      basePriceMedium: 125,
+      basePriceLarge: 150,
+      vehiclePrices: [
+        {
+          vehicleTypeId: "car",
+          price: 110,
+          duration: 70,
+          isAvailable: true,
+        },
+        {
+          vehicleTypeId: "van",
+          price: 180,
+          duration: 120,
+          isAvailable: true,
+        },
+      ],
+    };
+
+    expect(
+      getEffectiveServicePricingForVehicle(service, {
+        vehicleSize: "large",
+        vehicleTypeId: "van",
+      }),
+    ).toEqual({ price: 180, duration: 120, isAvailable: true });
+    expect(
+      isServiceAvailableForVehicle(service, {
+        vehicleSize: "large",
+        vehicleTypeId: "van",
+      }),
+    ).toBe(true);
+  });
+
+  test("treats a missing exact vehicle type row as unavailable", () => {
+    const service = {
+      isActive: true,
+      duration: 60,
+      basePriceSmall: 100,
+      basePriceMedium: 125,
+      basePriceLarge: 150,
+      vehiclePrices: [
+        {
+          vehicleTypeId: "car",
+          price: 110,
+          duration: 70,
+          isAvailable: true,
+        },
+      ],
+    };
+
+    expect(
+      getEffectiveServicePricingForVehicle(service, {
+        vehicleSize: "large",
+        vehicleTypeId: "van",
+      }),
+    ).toEqual({ price: 0, duration: 60, isAvailable: false });
+    expect(
+      isServiceAvailableForVehicle(service, {
+        vehicleSize: "large",
+        vehicleTypeId: "van",
+      }),
+    ).toBe(false);
+  });
+
+  test("falls back to matching legacy size rows when a vehicle has no type id", () => {
+    const service = {
+      isActive: true,
+      duration: 60,
+      vehiclePrices: [
+        {
+          vehicleTypeId: "car",
+          price: 110,
+          duration: 70,
+          isAvailable: true,
+          vehicleType: { legacySize: "small" as const },
+        },
+        {
+          vehicleTypeId: "suv",
+          price: 145,
+          duration: 95,
+          isAvailable: true,
+          vehicleType: { legacySize: "medium" as const },
+        },
+      ],
+    };
+
+    expect(
+      getEffectiveServicePricingForVehicle(service, {
+        vehicleSize: "medium",
+      }),
+    ).toEqual({ price: 145, duration: 95, isAvailable: true });
+  });
+
+  test("falls back to legacy price fields when no vehicle rows exist", () => {
+    const service = {
+      isActive: true,
+      duration: 80,
+      basePriceSmall: 100,
+      basePriceMedium: 125,
+      basePriceLarge: 150,
+    };
+
+    expect(
+      getEffectiveServicePricingForVehicle(service, {
+        vehicleSize: "large",
+        vehicleTypeId: "truck",
+      }),
+    ).toEqual({ price: 150, duration: 80, isAvailable: true });
+  });
+});

--- a/convex/lib/pricing.ts
+++ b/convex/lib/pricing.ts
@@ -17,8 +17,10 @@ type ServicePricingShape = {
   basePriceSmall?: number;
   basePriceMedium?: number;
   basePriceLarge?: number;
+  duration?: number;
   isActive?: boolean;
   serviceType?: ServiceType;
+  vehiclePrices?: ServiceVehiclePriceShape[];
 };
 
 type PetFeePricingShape = {
@@ -44,6 +46,64 @@ export function getEffectiveServicePrice(
     return service.basePriceLarge ?? service.basePriceMedium ?? fallback;
   }
   return service.basePriceMedium ?? fallback;
+}
+
+export function getEffectiveServicePricingForVehicle(
+  service: ServicePricingShape,
+  vehicle: {
+    vehicleSize: VehicleSize;
+    vehicleTypeId?: string | null;
+  },
+): {
+  price: number;
+  duration: number;
+  isAvailable: boolean;
+} {
+  const fallbackDuration = Math.max(0, service.duration ?? 0);
+  const rows = service.vehiclePrices ?? [];
+
+  if (rows.length > 0) {
+    const exactRow = vehicle.vehicleTypeId
+      ? rows.find((row) => row.vehicleTypeId === vehicle.vehicleTypeId)
+      : undefined;
+    const legacyRow = !vehicle.vehicleTypeId
+      ? rows.find(
+          (row) => row.vehicleType?.legacySize === vehicle.vehicleSize,
+        )
+      : undefined;
+    const row = exactRow ?? legacyRow;
+
+    if (!row) {
+      return { price: 0, duration: fallbackDuration, isAvailable: false };
+    }
+
+    const price = Number.isFinite(row.price) ? row.price : 0;
+    return {
+      price,
+      duration: Math.max(0, row.duration ?? fallbackDuration),
+      isAvailable: row.isAvailable && price > 0,
+    };
+  }
+
+  const price = getEffectiveServicePrice(service, vehicle.vehicleSize);
+  return {
+    price,
+    duration: fallbackDuration,
+    isAvailable: service.isActive !== false && price > 0,
+  };
+}
+
+export function isServiceAvailableForVehicle(
+  service: ServicePricingShape,
+  vehicle: {
+    vehicleSize: VehicleSize;
+    vehicleTypeId?: string | null;
+  },
+): boolean {
+  return (
+    service.isActive === true &&
+    getEffectiveServicePricingForVehicle(service, vehicle).isAvailable
+  );
 }
 
 export function hasAnyPositiveServicePrice(service: ServicePricingShape): boolean {


### PR DESCRIPTION
## Summary

- Filter marketing-site and dashboard booking products by the selected vehicle type.
- Use vehicle-type matrix pricing/duration in service cards, order previews, and draft duration recalculation.
- Sum service duration across every selected vehicle so multi-vehicle appointments block the full appointment time.
- Keep legacy S/M/L pricing as the fallback during rollout.
- Document the change in the changelog.

## Implementation Notes

- Added shared vehicle-aware pricing helpers in `convex/lib/pricing.ts`.
- Updated booking UIs to remove selections that become unavailable after vehicle changes.
- Patched internal booking draft duration recalculation used by payment flows.

## Testing Notes

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test:once`
- `git diff --check`

Closes #42
