### PR TITLE
fix: improve vehicle search matching and remove EPA/NHTSA labels

### DIFF
--- a/components/forms/vehicle-lookup-card.tsx
+++ b/components/forms/vehicle-lookup-card.tsx
@@ -129,8 +129,7 @@ export function VehicleLookupCard({
     const parsed = parseVehicleQuery(query);
     const canSearch =
       parsed.make &&
-      query.trim().length >= 3 &&
-      (isValidYear(parsed.year) || Boolean(parsed.model));
+      query.trim().length >= 3;
     if (!canSearch) {
       setSuggestions([]);
       setIsSearching(false);
@@ -369,16 +368,13 @@ export function VehicleLookupCard({
                 <button
                   key={`${suggestion.source}-${suggestion.label}`}
                   type="button"
-                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm hover:bg-muted"
+                  className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-muted"
                   onMouseDown={(event) => {
                     event.preventDefault();
                     selectSuggestion(suggestion);
                   }}
                 >
                   <span>{suggestion.label}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {suggestion.source === "fuelEconomy" ? "EPA" : "NHTSA"}
-                  </span>
                 </button>
               ))}
               {parseVehicleQuery(query).year && parseVehicleQuery(query).model && (

--- a/convex/vehicleTypes.test.ts
+++ b/convex/vehicleTypes.test.ts
@@ -144,6 +144,52 @@ describe("vehicleTypes", () => {
     expect(results).toHaveLength(8);
   });
 
+  test("searches vehicles when only make is specified (year and model omitted)", async () => {
+    const t = convexTest(schema, modules);
+    const newestYear = new Date().getFullYear() + 1;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const urlString = String(url);
+        if (urlString.includes("/menu/make")) {
+          return Response.json({
+            menuItem: [{ text: "Kia", value: "Kia" }],
+          });
+        }
+        if (urlString.includes("/menu/model")) {
+          return Response.json({
+            menuItem: [
+              { text: "Sorento AWD", value: "Sorento AWD" },
+              { text: "Sportage", value: "Sportage" },
+            ],
+          });
+        }
+        return Response.json({}, { status: 404 });
+      }),
+    );
+
+    const results = await t.action(api.vehicleTypes.searchModels, {
+      query: "Kia",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toEqual({
+      year: newestYear,
+      make: "Kia",
+      model: "Sorento AWD",
+      label: `${newestYear} Kia Sorento AWD`,
+      source: "fuelEconomy",
+    });
+    expect(results[1]).toEqual({
+      year: newestYear,
+      make: "Kia",
+      model: "Sportage",
+      label: `${newestYear} Kia Sportage`,
+      source: "fuelEconomy",
+    });
+  });
+
   test("falls back to vPIC when FuelEconomy lookup fails", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/vehicleTypes.ts
+++ b/convex/vehicleTypes.ts
@@ -367,9 +367,7 @@ export const searchModels = action({
 
     const [makeQuery = "", ...modelParts] = vehicleQuery.toLowerCase().split(" ");
     const modelQuery = modelParts.join(" ");
-    if (!year && !modelQuery) {
-      return [];
-    }
+
     const suggestions: Array<{
       year: number;
       make: string;


### PR DESCRIPTION
## Summary
This PR improves the vehicle lookup autocomplete matching capability by allowing searches where only the make is specified, and removes the EPA/NHTSA source labels in the suggestions dropdown as they are unnecessary clutter for the end-user.

## Implementation Notes
- **Backend (convex/vehicleTypes.ts)**: Removed the guard condition `if (!year && !modelQuery) { return []; }` in the `searchModels` action. Now, a query containing just a make will query fuel economy data across the default last 8 years.
- **Frontend (components/forms/vehicle-lookup-card.tsx)**:
  - Relaxed the frontend autocomplete trigger constraint `canSearch` so that it doesn't require a year or a model query to start searching, only requiring a make query with overall input length >= 3.
  - Removed the `EPA` / `NHTSA` badge element displayed alongside each vehicle suggestion in the dropdown.
  - Adjusted button flex properties to flow naturally after removing the label span.

## Testing Notes
- Added a new unit test in `convex/vehicleTypes.test.ts` named `"searches vehicles when only make is specified (year and model omitted)"` to verify the new behavior.
- Verified typechecking and lint rules passed successfully.
- Verified all 139 test cases pass successfully.

Closes #45