### PR TITLE
fix: make book and booking routes public in Clerk middleware

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -3,8 +3,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { fetchQuery } from "convex/nextjs";
 import { api } from "@/convex/_generated/api";
 import { getProtectedRouteRedirect, getRoleHomePath } from "@/lib/auth-routing";
-
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/book(.*)",
+  "/booking(.*)",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+]);
 
 const isOnboardingRoute = createRouteMatcher(["/onboarding(.*)"]);
 const isAdminRoute = createRouteMatcher(["/admin(.*)"]);


### PR DESCRIPTION
## Summary
This PR adds `/book(.*)` and `/booking(.*)` to the public route matcher in Clerk middleware (`proxy.ts`).

## Implementation Notes
- **Middleware (`proxy.ts`)**: Added `/book(.*)` and `/booking(.*)` to `isPublicRoute`. This prevents Clerk from forcing unauthenticated users to sign in when accessing `/book` or completing/canceling/resuming bookings, restoring the behavior of the modal-based flow where guests could book, checkout, and claim accounts afterward.

## Testing Notes
- Verified all 139 vitest tests run and pass.
- Verified TypeScript typecheck and ESLint checks pass.

Closes #49