### PR TITLE
feat: show deposit details in order summary and update travel fee threshold

### DIFF
--- a/app/admin/out-of-area/page.tsx
+++ b/app/admin/out-of-area/page.tsx
@@ -1,0 +1,7 @@
+import OutOfAreaRequestsClient from "@/components/admin/out-of-area-requests-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function OutOfAreaPage() {
+  return <OutOfAreaRequestsClient />;
+}

--- a/components/admin/admin-mobile-nav.tsx
+++ b/components/admin/admin-mobile-nav.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   FlaskConical,
   LayoutDashboard,
+  MapPinned,
   Settings,
   Star,
   Users,
@@ -60,6 +61,11 @@ const navItems = [
     href: "/admin/logs",
   },
   {
+    title: "Out-of-Area",
+    icon: MapPinned,
+    href: "/admin/out-of-area",
+  },
+  {
     title: "Payments",
     icon: CreditCard,
     href: "/admin/payments",
@@ -93,6 +99,7 @@ export default function AdminMobileNav() {
   const unpaidInvoicesCount = useQuery(api.invoices.getUnpaidInvoicesCountAdmin) ?? 0;
   const newReviewsCount = useQuery(api.reviews.getNewReviewsCount) ?? 0;
   const pendingTripLogsCount = useQuery(api.tripLogs.getPendingRequiredCount) ?? 0;
+  const outOfAreaRequestCount = useQuery(api.bookingDrafts.getOutOfAreaRequestCount) ?? 0;
 
   const getItemCount = (href: string) => {
     if (href === "/admin/appointments") return pendingAppointmentsCount;
@@ -100,6 +107,7 @@ export default function AdminMobileNav() {
     if (href === "/admin/payments") return unpaidInvoicesCount;
     if (href === "/admin/reviews") return newReviewsCount;
     if (href === "/admin/logs") return pendingTripLogsCount;
+    if (href === "/admin/out-of-area") return outOfAreaRequestCount;
     return 0;
   };
 

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   BarChart3,
   CreditCard,
   LogOut,
+  MapPinned,
   RefreshCw,
   Star,
   FileText,
@@ -69,6 +70,11 @@ const menuItems = [
     href: "/admin/logs",
   },
   {
+    title: "Out-of-Area",
+    icon: MapPinned,
+    href: "/admin/out-of-area",
+  },
+  {
     title: "Subscriptions",
     icon: RefreshCw,
     href: "/admin/subscriptions",
@@ -104,6 +110,7 @@ export default function AdminSidebar() {
   const newReviewsCount = useQuery(api.reviews.getNewReviewsCount) ?? 0;
   const pendingTripLogsCount = useQuery(api.tripLogs.getPendingRequiredCount) ?? 0;
   const subscriptionAlertCount = useQuery(api.subscriptions.getActiveCount) ?? 0;
+  const outOfAreaRequestCount = useQuery(api.bookingDrafts.getOutOfAreaRequestCount) ?? 0;
 
   return (
     <Sidebar>
@@ -148,6 +155,8 @@ export default function AdminSidebar() {
                   count = newReviewsCount;
                 } else if (item.href === "/admin/logs") {
                   count = pendingTripLogsCount;
+                } else if (item.href === "/admin/out-of-area") {
+                  count = outOfAreaRequestCount;
                 } else if (item.href === "/admin/subscriptions") {
                   count = subscriptionAlertCount;
                 }

--- a/components/admin/out-of-area-requests-client.tsx
+++ b/components/admin/out-of-area-requests-client.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import { useState } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { DataTable } from "@/components/ui/data-table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import {
+  AlertCircle,
+  ArrowUpDown,
+  Mail,
+  MapPin,
+  MoreHorizontal,
+  Phone,
+} from "lucide-react";
+
+type RequestStatus =
+  | "new"
+  | "reviewing"
+  | "contacted"
+  | "approved"
+  | "declined"
+  | "notified";
+
+type OutOfAreaRequest = {
+  _id: Id<"outOfAreaRequests">;
+  _creationTime: number;
+  customerName: string;
+  customerEmail: string;
+  customerPhone: string;
+  address: {
+    street: string;
+    city: string;
+    state: string;
+    zip: string;
+    notes?: string;
+    latitude?: number;
+    longitude?: number;
+  };
+  scheduledDate?: string;
+  scheduledTime?: string;
+  vehicle?: {
+    year?: number;
+    make?: string;
+    model?: string;
+    vehicleTypeName?: string;
+    color?: string;
+    licensePlate?: string;
+    hasPet?: boolean;
+  };
+  estimatedDistanceMiles?: number;
+  estimatedTravelFee?: number;
+  status: RequestStatus;
+  adminNotes?: string;
+  createdAt: number;
+};
+
+const statusLabels: Record<RequestStatus, string> = {
+  new: "New",
+  reviewing: "Reviewing",
+  contacted: "Contacted",
+  approved: "Approved",
+  declined: "Declined",
+  notified: "Notified",
+};
+
+function statusVariant(status: RequestStatus) {
+  if (status === "new") return "destructive";
+  if (status === "approved") return "default";
+  if (status === "declined") return "outline";
+  return "secondary";
+}
+
+function formatDate(timestamp: number) {
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(time?: string) {
+  if (!time) return "No time";
+  const [hourValue, minute = "00"] = time.split(":");
+  const hour = Number(hourValue);
+  if (!Number.isFinite(hour)) return time;
+  const suffix = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 || 12;
+  return `${displayHour}:${minute} ${suffix}`;
+}
+
+function vehicleLabel(request: OutOfAreaRequest) {
+  if (!request.vehicle) return "No vehicle";
+  return (
+    [
+      request.vehicle.year,
+      request.vehicle.make,
+      request.vehicle.model,
+    ]
+      .filter(Boolean)
+      .join(" ") || "Vehicle details pending"
+  );
+}
+
+function locationLabel(request: OutOfAreaRequest) {
+  return [
+    request.address.street,
+    request.address.city,
+    request.address.state,
+    request.address.zip,
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
+
+export default function OutOfAreaRequestsClient() {
+  const requests = useQuery(api.bookingDrafts.listOutOfAreaRequestsForAdmin);
+  const updateStatus = useMutation(api.bookingDrafts.updateOutOfAreaRequestStatus);
+  const [selectedRequest, setSelectedRequest] =
+    useState<OutOfAreaRequest | null>(null);
+  const [adminNotes, setAdminNotes] = useState("");
+  const [updatingId, setUpdatingId] = useState<Id<"outOfAreaRequests"> | null>(
+    null,
+  );
+
+  const copyValue = async (value: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`Copied ${label}`);
+    } catch {
+      toast.error(`Failed to copy ${label}`);
+    }
+  };
+
+  const setStatus = async (request: OutOfAreaRequest, status: RequestStatus) => {
+    setUpdatingId(request._id);
+    try {
+      await updateStatus({
+        requestId: request._id,
+        status,
+        adminNotes:
+          selectedRequest?._id === request._id
+            ? adminNotes || undefined
+            : request.adminNotes,
+      });
+      toast.success(`Marked ${statusLabels[status].toLowerCase()}`);
+    } catch {
+      toast.error("Failed to update request");
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const columns: ColumnDef<OutOfAreaRequest>[] = [
+    {
+      accessorKey: "customerName",
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Customer
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <div className="min-w-[180px]">
+          <p className="font-medium">{row.original.customerName}</p>
+          <p className="text-xs text-muted-foreground">
+            Requested {formatDate(row.original.createdAt)}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "contact",
+      accessorFn: (row) => `${row.customerEmail} ${row.customerPhone}`,
+      header: "Contact",
+      cell: ({ row }) => (
+        <div className="min-w-[220px] space-y-1 text-sm text-muted-foreground">
+          <p className="flex items-center gap-2">
+            <Mail className="h-3.5 w-3.5" />
+            {row.original.customerEmail}
+          </p>
+          <p className="flex items-center gap-2">
+            <Phone className="h-3.5 w-3.5" />
+            {row.original.customerPhone}
+          </p>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "address.city",
+      header: "Location",
+      cell: ({ row }) => (
+        <div className="flex min-w-[220px] items-center gap-2 text-sm text-muted-foreground">
+          <MapPin className="h-3.5 w-3.5" />
+          <span>{locationLabel(row.original)}</span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "scheduledDate",
+      header: "Requested Time",
+      cell: ({ row }) => (
+        <div className="min-w-[150px] text-sm">
+          <p>{row.original.scheduledDate || "No date"}</p>
+          <p className="text-xs text-muted-foreground">
+            {formatTime(row.original.scheduledTime)}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "travel",
+      accessorFn: (row) => row.estimatedTravelFee ?? 0,
+      header: "Travel",
+      cell: ({ row }) => (
+        <div className="min-w-[130px] text-sm">
+          <p className="font-medium">
+            {row.original.estimatedTravelFee !== undefined
+              ? `$${row.original.estimatedTravelFee.toFixed(2)}`
+              : "Unavailable"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {row.original.estimatedDistanceMiles !== undefined
+              ? `${row.original.estimatedDistanceMiles.toFixed(1)} miles`
+              : "No distance"}
+          </p>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+      cell: ({ row }) => (
+        <Badge variant={statusVariant(row.original.status)}>
+          {statusLabels[row.original.status]}
+        </Badge>
+      ),
+    },
+    {
+      id: "actions",
+      enableHiding: false,
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="h-8 w-8 p-0"
+              onClick={(event) => event.stopPropagation()}
+              disabled={updatingId === row.original._id}
+            >
+              <span className="sr-only">Open actions</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem
+              onClick={(event) => {
+                event.stopPropagation();
+                setSelectedRequest(row.original);
+                setAdminNotes(row.original.adminNotes || "");
+              }}
+            >
+              View Details
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => copyValue(row.original.customerEmail, "email")}
+            >
+              Copy Email
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => copyValue(row.original.customerPhone, "phone")}
+            >
+              Copy Phone
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {Object.keys(statusLabels).map((status) => (
+              <DropdownMenuItem
+                key={status}
+                onClick={() =>
+                  setStatus(row.original, status as RequestStatus)
+                }
+              >
+                Mark {statusLabels[status as RequestStatus]}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+    },
+  ];
+
+  if (requests === undefined) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-3xl font-bold">Out-of-Area Requests</h2>
+          <p className="mt-1 text-muted-foreground">
+            Review customers outside the regular service area
+          </p>
+        </div>
+        <Card>
+          <CardContent className="py-10">
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <Skeleton key={index} className="h-12 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (requests === null) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-3xl font-bold">Out-of-Area Requests</h2>
+          <p className="mt-1 text-muted-foreground">
+            Review customers outside the regular service area
+          </p>
+        </div>
+        <Card className="py-12 text-center">
+          <CardContent>
+            <AlertCircle className="mx-auto mb-4 h-16 w-16 text-destructive" />
+            <h3 className="mb-2 text-xl font-semibold">Unable to load requests</h3>
+            <p className="mb-6 text-muted-foreground">
+              There was an error loading out-of-area requests.
+            </p>
+            <Button onClick={() => window.location.reload()}>Try Again</Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <div>
+        <h2 className="text-3xl font-bold">Out-of-Area Requests</h2>
+        <p className="text-muted-foreground">
+          Review manual service requests before scheduling or taking payment
+        </p>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={requests as OutOfAreaRequest[]}
+        filterColumn="customerName"
+        filterPlaceholder="Search requests by customer..."
+        tableMinWidthClass="min-w-[1180px]"
+        onRowClick={(request) => {
+          setSelectedRequest(request as OutOfAreaRequest);
+          setAdminNotes((request as OutOfAreaRequest).adminNotes || "");
+        }}
+      />
+
+      {selectedRequest && (
+        <Dialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setSelectedRequest(null);
+          }}
+        >
+          <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>{selectedRequest.customerName}</DialogTitle>
+              <DialogDescription>
+                Out-of-area request from {formatDate(selectedRequest.createdAt)}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-md border p-3">
+                <p className="mb-2 text-sm font-semibold">Contact</p>
+                <p className="text-sm">{selectedRequest.customerEmail}</p>
+                <p className="text-sm">{selectedRequest.customerPhone}</p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="mb-2 text-sm font-semibold">Requested Time</p>
+                <p className="text-sm">
+                  {selectedRequest.scheduledDate || "No date"} at{" "}
+                  {formatTime(selectedRequest.scheduledTime)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3 sm:col-span-2">
+                <p className="mb-2 text-sm font-semibold">Location</p>
+                <p className="text-sm">{locationLabel(selectedRequest)}</p>
+                {selectedRequest.address.notes && (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {selectedRequest.address.notes}
+                  </p>
+                )}
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="mb-2 text-sm font-semibold">Vehicle</p>
+                <p className="text-sm">{vehicleLabel(selectedRequest)}</p>
+                {selectedRequest.vehicle?.vehicleTypeName && (
+                  <p className="text-sm text-muted-foreground">
+                    {selectedRequest.vehicle.vehicleTypeName}
+                  </p>
+                )}
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="mb-2 text-sm font-semibold">Estimate</p>
+                <p className="text-sm">
+                  {selectedRequest.estimatedTravelFee !== undefined
+                    ? `$${selectedRequest.estimatedTravelFee.toFixed(2)}`
+                    : "Travel fee unavailable"}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {selectedRequest.estimatedDistanceMiles !== undefined
+                    ? `${selectedRequest.estimatedDistanceMiles.toFixed(1)} miles`
+                    : "Distance unavailable"}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-semibold">Admin Notes</p>
+              <Textarea
+                value={adminNotes}
+                onChange={(event) => setAdminNotes(event.target.value)}
+                placeholder="Add internal notes"
+              />
+            </div>
+
+            <div className="flex flex-wrap justify-end gap-2">
+              {Object.keys(statusLabels).map((status) => (
+                <Button
+                  key={status}
+                  type="button"
+                  variant={
+                    selectedRequest.status === status ? "default" : "outline"
+                  }
+                  onClick={() =>
+                    setStatus(selectedRequest, status as RequestStatus)
+                  }
+                  disabled={updatingId === selectedRequest._id}
+                >
+                  {statusLabels[status as RequestStatus]}
+                </Button>
+              ))}
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+}

--- a/components/booking/booking-flow.tsx
+++ b/components/booking/booking-flow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { useQuery, useAction, useConvex } from "convex/react";
+import { useQuery, useAction, useConvex, useMutation } from "convex/react";
 import { useUser } from "@clerk/nextjs";
 import { useBookingStore } from "@/hooks/use-booking-store";
 import { api } from "@/convex/_generated/api";
@@ -38,7 +38,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
-import { ArrowLeft, ArrowRight, X, ChevronDown, ChevronUp } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  X,
+} from "lucide-react";
 import AddressInput from "@/components/ui/address-input";
 import {
   VehicleLookupCard,
@@ -77,6 +86,8 @@ const step1Schema = z.object({
   state: z.string().min(1, "State is required"),
   zip: z.string().optional(),
   locationNotes: z.string().optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
 });
 
 const step2Schema = z.object({
@@ -136,6 +147,8 @@ type Step2Data = z.infer<typeof step2Schema>;
 type Step3Data = z.infer<typeof step3Schema>;
 type Step4Data = z.infer<typeof step4Schema>;
 
+type OutOfAreaMode = "idle" | "notify" | "review" | "submitted";
+
 export default function BookingFlow() {
   const router = useRouter();
   const {
@@ -166,6 +179,25 @@ export default function BookingFlow() {
   const [activeServiceSection, setActiveServiceSection] = useState<Record<number, "packages" | "addons" | "subscriptions" | "">>(
     {},
   );
+  const [outOfAreaMode, setOutOfAreaMode] = useState<OutOfAreaMode>("idle");
+  const [notifyEmail, setNotifyEmail] = useState("");
+  const [isNotifySubmitting, setIsNotifySubmitting] = useState(false);
+  const [reviewContact, setReviewContact] = useState({
+    name: step2Data?.name || "",
+    email: step2Data?.email || "",
+    phone: step2Data?.phone || "",
+    smsOptIn: step2Data?.smsOptIn ?? false,
+  });
+  const [reviewVehicle, setReviewVehicle] = useState<VehicleLookupValue>({
+    year: "",
+    make: "",
+    model: "",
+    color: "",
+    licensePlate: "",
+    size: "small",
+    hasPet: false,
+  });
+  const [isReviewSubmitting, setIsReviewSubmitting] = useState(false);
 
   const step1Form = useForm<Step1Data>({
     resolver: zodResolver(step1Schema),
@@ -179,11 +211,14 @@ export default function BookingFlow() {
       state: step1Data?.state || "",
       zip: step1Data?.zip || "",
       locationNotes: step1Data?.locationNotes || "",
+      latitude: step1Data?.latitude ?? undefined,
+      longitude: step1Data?.longitude ?? undefined,
     },
   });
 
   const services = useQuery(api.services.list);
   const petFeeSettings = useQuery(api.petFeeSettings.get);
+  const depositSettings = useQuery(api.depositSettings.get);
   const bookingReadiness = useQuery(api.setupReadiness.getPublicBookingReadiness);
   const nextBookableDate = useQuery(
     api.availability.getNextBookableDate,
@@ -192,6 +227,8 @@ export default function BookingFlow() {
   const upsertBookingDraft = useAction(api.bookingDrafts.createOrUpdate);
   const calculateTravelFee = useAction(api.travelFees.calculate);
   const createBookingCheckout = useAction(api.payments.createBookingCheckout);
+  const saveOutOfAreaLead = useMutation(api.bookingDrafts.saveOutOfAreaLead);
+  const saveOutOfAreaRequest = useMutation(api.bookingDrafts.saveOutOfAreaRequest);
   const convex = useConvex();
   const currentUser = useQuery(api.users.getCurrentUser, isSignedIn ? {} : "skip");
 
@@ -212,6 +249,132 @@ export default function BookingFlow() {
   const watchedState = step1Form.watch("state");
   const watchedZip = step1Form.watch("zip");
   const watchedLocationNotes = step1Form.watch("locationNotes");
+  const watchedLatitude = step1Form.watch("latitude");
+  const watchedLongitude = step1Form.watch("longitude");
+  const isOutOfAreaAddress =
+    watchedState.trim().length > 0 && watchedState.trim().toUpperCase() !== "AR";
+  const selectedAddressLabel = [watchedStreet, watchedCity, watchedState, watchedZip]
+    .filter(Boolean)
+    .join(", ");
+
+  const handleNotifySubmit = useCallback(async () => {
+    if (!notifyEmail || !notifyEmail.includes("@")) {
+      toast.error("Please enter a valid email address.");
+      return;
+    }
+    setIsNotifySubmitting(true);
+    try {
+      await saveOutOfAreaLead({
+        email: notifyEmail,
+        address: selectedAddressLabel,
+        latitude: watchedLatitude,
+        longitude: watchedLongitude,
+      });
+      setNotifyEmail("");
+      setOutOfAreaMode("submitted");
+      toast.success("Thank you! We'll notify you when we expand to your area.");
+    } catch (err) {
+      console.error("Failed to save lead:", err);
+      toast.error("Failed to submit. Please try again.");
+    } finally {
+      setIsNotifySubmitting(false);
+    }
+  }, [
+    notifyEmail,
+    saveOutOfAreaLead,
+    selectedAddressLabel,
+    watchedLatitude,
+    watchedLongitude,
+  ]);
+
+  const handleOutOfAreaReviewSubmit = useCallback(async () => {
+    if (!reviewContact.name.trim()) {
+      toast.error("Please enter your name.");
+      return;
+    }
+    if (!reviewContact.email.includes("@")) {
+      toast.error("Please enter a valid email address.");
+      return;
+    }
+    if (reviewContact.phone.replace(/\D/g, "").length < 10) {
+      toast.error("Please enter a valid phone number.");
+      return;
+    }
+
+    setIsReviewSubmitting(true);
+    try {
+      const scheduledDateValue = step1Form.getValues("scheduledDate");
+      const scheduledDate =
+        scheduledDateValue instanceof Date
+          ? scheduledDateValue.toISOString().split("T")[0]
+          : undefined;
+      const vehicleYear = /^\d{4}$/.test(reviewVehicle.year)
+        ? Number(reviewVehicle.year)
+        : undefined;
+      const hasVehicleDetails =
+        vehicleYear || reviewVehicle.make.trim() || reviewVehicle.model.trim();
+
+      await saveOutOfAreaRequest({
+        name: reviewContact.name,
+        email: reviewContact.email,
+        phone: reviewContact.phone,
+        smsOptIn: reviewContact.smsOptIn,
+        address: {
+          street: watchedStreet,
+          city: watchedCity,
+          state: watchedState,
+          zip: watchedZip || "",
+          notes: watchedLocationNotes || undefined,
+          latitude: watchedLatitude,
+          longitude: watchedLongitude,
+        },
+        scheduledDate,
+        scheduledTime: step1Form.getValues("scheduledTime") || undefined,
+        estimatedDistanceMiles: travelQuote?.distanceMiles,
+        estimatedTravelFee: travelQuote?.fee,
+        vehicle: hasVehicleDetails
+          ? {
+              year: vehicleYear,
+              make: reviewVehicle.make || undefined,
+              model: reviewVehicle.model || undefined,
+              vehicleTypeId: reviewVehicle.vehicleTypeId as
+                | Id<"vehicleTypes">
+                | undefined,
+              vehicleTypeName: reviewVehicle.vehicleTypeName,
+              classification: reviewVehicle.classification,
+              size: reviewVehicle.size,
+              color: reviewVehicle.color || undefined,
+              licensePlate: reviewVehicle.licensePlate || undefined,
+              hasPet: reviewVehicle.hasPet,
+            }
+          : undefined,
+      });
+      setOutOfAreaMode("submitted");
+      toast.success("Request received. We'll review it and reach out.");
+    } catch (err) {
+      console.error("Failed to save out-of-area request:", err);
+      toast.error("Failed to submit your request. Please try again.");
+    } finally {
+      setIsReviewSubmitting(false);
+    }
+  }, [
+    reviewContact.email,
+    reviewContact.name,
+    reviewContact.phone,
+    reviewContact.smsOptIn,
+    reviewVehicle,
+    saveOutOfAreaRequest,
+    step1Form,
+    travelQuote?.distanceMiles,
+    travelQuote?.fee,
+    watchedCity,
+    watchedLatitude,
+    watchedLocationNotes,
+    watchedLongitude,
+    watchedState,
+    watchedStreet,
+    watchedZip,
+  ]);
 
   useEffect(() => {
     if (
@@ -231,6 +394,8 @@ export default function BookingFlow() {
           state: watchedState,
           zip: watchedZip,
           notes: watchedLocationNotes || undefined,
+          latitude: watchedLatitude,
+          longitude: watchedLongitude,
         },
       })
         .then(setTravelQuote)
@@ -244,6 +409,8 @@ export default function BookingFlow() {
     watchedState,
     watchedStreet,
     watchedZip,
+    watchedLatitude,
+    watchedLongitude,
   ]);
 
   const schedulingDuration = useMemo(() => {
@@ -412,6 +579,25 @@ export default function BookingFlow() {
   }, [currentUser, step2Data?.smsOptIn, step2Form]);
 
   useEffect(() => {
+    if (!isLoaded || !isSignedIn || !user) return;
+
+    setReviewContact((current) => ({
+      name: current.name || user.fullName || "",
+      email: current.email || user.primaryEmailAddress?.emailAddress || "",
+      phone: current.phone,
+      smsOptIn:
+        current.smsOptIn ||
+        currentUser?.notificationPreferences?.operationalSmsConsent?.optedIn ||
+        false,
+    }));
+  }, [
+    currentUser?.notificationPreferences?.operationalSmsConsent?.optedIn,
+    isLoaded,
+    isSignedIn,
+    user,
+  ]);
+
+  useEffect(() => {
     if (!bookingReadiness?.isReady || !nextBookableDate) {
       return;
     }
@@ -437,6 +623,10 @@ export default function BookingFlow() {
       console.log("Processing address selection:", address);
       localStorage.setItem("selectedAddress", JSON.stringify(address));
 
+      setOutOfAreaMode("idle");
+      setNotifyEmail("");
+      step1Form.clearErrors("state");
+
       const streetNumber = address.number || "";
       const streetName = address.street || "";
       const fullStreet = streetNumber
@@ -455,6 +645,14 @@ export default function BookingFlow() {
         shouldDirty: true,
       });
       step1Form.setValue("zip", address.postalCode || "", {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+      step1Form.setValue("latitude", address.latitude, {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+      step1Form.setValue("longitude", address.longitude, {
         shouldValidate: true,
         shouldDirty: true,
       });
@@ -524,6 +722,15 @@ export default function BookingFlow() {
         isValid = await step1Form.trigger();
         if (isValid) {
           const formData = step1Form.getValues();
+          const isStateOutOfArea = formData.state?.trim().toUpperCase() !== "AR";
+          if (isStateOutOfArea) {
+            step1Form.setError("state", {
+              type: "manual",
+              message: "Please request manual review for out-of-area service.",
+            });
+            setOutOfAreaMode((current) => current === "submitted" ? current : "review");
+            return;
+          }
           setStep1Data(formData);
           localStorage.setItem("appointmentFormData", JSON.stringify(formData));
           setCurrentStep(2);
@@ -684,6 +891,8 @@ export default function BookingFlow() {
           state: step1Data.state,
           zip: step1Data.zip || "",
           notes: step1Data.locationNotes,
+          latitude: step1Data.latitude,
+          longitude: step1Data.longitude,
         },
         vehicles: step3Data.vehicles.map((vehicle, index) => ({
           year: parseInt(vehicle.year),
@@ -922,6 +1131,162 @@ export default function BookingFlow() {
                 label="Service Address"
                 placeholder="Search for your service address"
               />
+              {isOutOfAreaAddress && (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+                  {outOfAreaMode === "submitted" ? (
+                    <div className="flex gap-3">
+                      <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
+                      <div className="space-y-1">
+                        <p className="font-semibold">Request received</p>
+                        <p className="text-sm text-amber-900/80 dark:text-amber-100/80">
+                          We saved your information and will reach out if we can serve this area or when service expands.
+                        </p>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      <div className="flex gap-3">
+                        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+                        <div className="space-y-1">
+                          <p className="font-semibold">Manual review required for this area</p>
+                          <p className="text-sm text-amber-900/80 dark:text-amber-100/80">
+                            We are not regularly serving {watchedState} yet. This trip may be possible with an estimated travel fee of{" "}
+                            <span className="font-semibold">
+                              {travelQuote ? `$${travelQuote.fee.toFixed(2)}` : "calculating"}
+                            </span>
+                            , but we need to review timing before taking payment.
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => setOutOfAreaMode("review")}
+                          className="bg-amber-900 text-white hover:bg-amber-800 dark:bg-amber-200 dark:text-amber-950 dark:hover:bg-amber-100"
+                        >
+                          Request Review
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setOutOfAreaMode("notify")}
+                          className="border-amber-300 bg-white/70 text-amber-950 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
+                        >
+                          Get Notified
+                        </Button>
+                      </div>
+
+                      {outOfAreaMode === "notify" && (
+                        <div className="grid gap-3 rounded-lg border border-amber-200 bg-white/70 p-3 dark:border-amber-900 dark:bg-background/50 sm:grid-cols-[1fr_auto]">
+                          <Input
+                            type="email"
+                            value={notifyEmail}
+                            onChange={(event) => setNotifyEmail(event.target.value)}
+                            placeholder="Email address"
+                            className="bg-background"
+                          />
+                          <Button
+                            type="button"
+                            onClick={handleNotifySubmit}
+                            disabled={isNotifySubmitting}
+                          >
+                            {isNotifySubmitting && (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            )}
+                            Submit
+                          </Button>
+                        </div>
+                      )}
+
+                      {outOfAreaMode === "review" && (
+                        <div className="space-y-4 rounded-lg border border-amber-200 bg-white/70 p-4 dark:border-amber-900 dark:bg-background/50">
+                          <div className="grid gap-3 sm:grid-cols-2">
+                            <div className="space-y-2">
+                              <FormLabel>Name</FormLabel>
+                              <Input
+                                value={reviewContact.name}
+                                onChange={(event) =>
+                                  setReviewContact((current) => ({
+                                    ...current,
+                                    name: event.target.value,
+                                  }))
+                                }
+                                className="bg-background"
+                              />
+                            </div>
+                            <div className="space-y-2">
+                              <FormLabel>Email</FormLabel>
+                              <Input
+                                type="email"
+                                value={reviewContact.email}
+                                onChange={(event) =>
+                                  setReviewContact((current) => ({
+                                    ...current,
+                                    email: event.target.value,
+                                  }))
+                                }
+                                className="bg-background"
+                              />
+                            </div>
+                            <div className="space-y-2">
+                              <FormLabel>Phone</FormLabel>
+                              <Input
+                                type="tel"
+                                value={reviewContact.phone}
+                                onChange={(event) =>
+                                  setReviewContact((current) => ({
+                                    ...current,
+                                    phone: event.target.value,
+                                  }))
+                                }
+                                className="bg-background"
+                              />
+                            </div>
+                            <div className="flex items-center justify-between rounded-md border border-border bg-background px-3 py-2">
+                              <div>
+                                <FormLabel>SMS updates</FormLabel>
+                                <p className="text-xs text-muted-foreground">Text me about this request</p>
+                              </div>
+                              <Switch
+                                checked={reviewContact.smsOptIn}
+                                onCheckedChange={(checked) =>
+                                  setReviewContact((current) => ({
+                                    ...current,
+                                    smsOptIn: checked,
+                                  }))
+                                }
+                              />
+                            </div>
+                          </div>
+
+                          <VehicleLookupCard
+                            value={reviewVehicle}
+                            onChange={setReviewVehicle}
+                            title="Vehicle"
+                            showColor
+                            showLicensePlate
+                            showPetToggle
+                          />
+
+                          <div className="flex justify-end">
+                            <Button
+                              type="button"
+                              onClick={handleOutOfAreaReviewSubmit}
+                              disabled={isReviewSubmitting}
+                            >
+                              {isReviewSubmitting && (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              )}
+                              Submit Review Request
+                            </Button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
               <FormField
                 control={step1Form.control}
                 name="street"
@@ -1456,7 +1821,7 @@ export default function BookingFlow() {
         {/* Step 5: Create Account & Payment */}
         {currentStep === 5 && (() => {
           const vehicleCount = vehiclePricingContexts.length;
-          const depositPerVehicle = 50;
+          const depositPerVehicle = depositSettings?.amountPerVehicle ?? 50;
           const depositTotal = depositPerVehicle * vehicleCount;
           const petFeeForSize = (size: "small" | "medium" | "large") => {
             if (petFeeSettings?.isActive === false) return 0;
@@ -1507,6 +1872,7 @@ export default function BookingFlow() {
           const orderTotal = serviceTotal + petFeeTotal + travelFeeTotal;
 
           const dueNow = paymentOption === "full" ? orderTotal : Math.min(depositTotal, orderTotal);
+          const remainingBalance = Math.max(0, orderTotal - dueNow);
 
           return (
             <div className="space-y-6">
@@ -1554,6 +1920,18 @@ export default function BookingFlow() {
                   <span className="text-foreground">Total</span>
                   <span className="text-foreground">${orderTotal.toFixed(2)}</span>
                 </div>
+                {paymentOption !== "full" && (
+                  <div className="mt-3 space-y-1 border-t border-border/30 pt-3">
+                    <div className="flex justify-between text-sm font-medium">
+                      <span className="text-muted-foreground">Deposit Due Today</span>
+                      <span className="text-foreground">${dueNow.toFixed(2)}</span>
+                    </div>
+                    <div className="flex justify-between text-sm font-medium">
+                      <span className="text-muted-foreground">Remaining Balance</span>
+                      <span className="text-foreground">${remainingBalance.toFixed(2)}</span>
+                    </div>
+                  </div>
+                )}
               </div>
 
               {/* Payment Option Selector */}
@@ -1647,7 +2025,7 @@ export default function BookingFlow() {
                 )}
                 {paymentOption === "in_person" && (
                   <p className="text-xs text-muted-foreground mt-1">
-                    Remaining balance of ${Math.max(0, orderTotal - depositTotal).toFixed(2)} will be collected in person.
+                    Remaining balance of ${remainingBalance.toFixed(2)} will be collected in person.
                   </p>
                 )}
               </div>

--- a/convex/bookingDrafts.test.ts
+++ b/convex/bookingDrafts.test.ts
@@ -1,0 +1,57 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { modules } from "./test.setup";
+
+describe("bookingDrafts out-of-area requests", () => {
+  test("saves a public out-of-area review request for admin follow-up", async () => {
+    const t = convexTest(schema, modules);
+
+    const requestId = await t.mutation(api.bookingDrafts.saveOutOfAreaRequest, {
+      name: "Taylor Outside",
+      email: "TAYLOR@example.com",
+      phone: "(501) 555-1234",
+      smsOptIn: true,
+      address: {
+        street: "100 River Rd",
+        city: "Memphis",
+        state: "TN",
+        zip: "38103",
+        notes: "Gate code 1234",
+        latitude: 35.1495,
+        longitude: -90.049,
+      },
+      scheduledDate: "2026-07-10",
+      scheduledTime: "10:00",
+      estimatedDistanceMiles: 137.4,
+      estimatedTravelFee: 103.05,
+      vehicle: {
+        year: 2024,
+        make: "Toyota",
+        model: "Camry",
+        size: "medium",
+        hasPet: false,
+      },
+    });
+
+    const stored = await t.run(async (ctx) => ctx.db.get(requestId));
+
+    expect(stored).toMatchObject({
+      customerName: "Taylor Outside",
+      customerEmail: "taylor@example.com",
+      customerPhone: "(501) 555-1234",
+      status: "new",
+      estimatedTravelFee: 103.05,
+      address: {
+        city: "Memphis",
+        state: "TN",
+      },
+      vehicle: {
+        year: 2024,
+        make: "Toyota",
+        model: "Camry",
+      },
+    });
+  });
+});

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -35,6 +35,8 @@ const addressValidator = v.object({
   state: v.string(),
   zip: v.string(),
   notes: v.optional(v.string()),
+  latitude: v.optional(v.number()),
+  longitude: v.optional(v.number()),
 });
 
 const beforePhotoValidator = v.object({
@@ -73,10 +75,46 @@ const draftVehicleValidator = v.object({
   serviceIds: v.optional(v.array(v.id("services"))),
 });
 
+const outOfAreaRequestVehicleValidator = v.object({
+  year: v.optional(v.number()),
+  make: v.optional(v.string()),
+  model: v.optional(v.string()),
+  vehicleTypeId: v.optional(v.id("vehicleTypes")),
+  vehicleTypeName: v.optional(v.string()),
+  classification: v.optional(
+    v.object({
+      source: v.union(
+        v.literal("fuelEconomy"),
+        v.literal("vpic"),
+        v.literal("manual"),
+        v.literal("fallback"),
+      ),
+      confidence: v.union(v.literal("high"), v.literal("medium"), v.literal("low")),
+      rawCategory: v.optional(v.string()),
+      needsAdminReview: v.boolean(),
+    }),
+  ),
+  size: v.optional(
+    v.union(v.literal("small"), v.literal("medium"), v.literal("large")),
+  ),
+  color: v.optional(v.string()),
+  licensePlate: v.optional(v.string()),
+  hasPet: v.optional(v.boolean()),
+});
+
 const bookingPaymentOptionValidator = v.union(
   v.literal("deposit"),
   v.literal("full"),
   v.literal("in_person"),
+);
+
+const outOfAreaRequestStatusValidator = v.union(
+  v.literal("new"),
+  v.literal("reviewing"),
+  v.literal("contacted"),
+  v.literal("approved"),
+  v.literal("declined"),
+  v.literal("notified"),
 );
 
 type ConvertedDraftResult = {
@@ -1126,6 +1164,11 @@ export const convertSuccessfulCheckout = internalMutation({
       vehicleServices.push({ vehicleId, serviceIds });
     });
 
+    let notes = "Created via checkout conversion";
+    if (draft.address.state.trim().toUpperCase() !== "AR") {
+      notes = `⚠️ OUT-OF-STATE BOOKING: Requires manual admin review. ${notes}`;
+    }
+
     const appointmentId = await ctx.db.insert("appointments", {
       userId: user._id,
       vehicleIds,
@@ -1143,7 +1186,7 @@ export const convertSuccessfulCheckout = internalMutation({
       },
       status: "pending",
       totalPrice: draft.totalPrice,
-      notes: "Created via checkout conversion",
+      notes,
       createdBy: user._id,
       paymentOption: draft.paymentOption,
       petFeeVehicleIds,
@@ -1491,5 +1534,119 @@ export const getSchedulerDefaults = query({
       holdDurationMs: HOLD_DURATION_MS,
       abandonedEmailDelayMs: ABANDONED_EMAIL_DELAY_MS,
     };
+  },
+});
+
+export const saveOutOfAreaLead = mutation({
+  args: {
+    email: v.string(),
+    address: v.string(),
+    latitude: v.optional(v.number()),
+    longitude: v.optional(v.number()),
+  },
+  returns: v.id("outOfAreaLeads"),
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("outOfAreaLeads", {
+      email: args.email,
+      address: args.address,
+      latitude: args.latitude,
+      longitude: args.longitude,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const saveOutOfAreaRequest = mutation({
+  args: {
+    name: v.string(),
+    email: v.string(),
+    phone: v.string(),
+    smsOptIn: v.optional(v.boolean()),
+    address: addressValidator,
+    scheduledDate: v.optional(v.string()),
+    scheduledTime: v.optional(v.string()),
+    vehicle: v.optional(outOfAreaRequestVehicleValidator),
+    estimatedDistanceMiles: v.optional(v.number()),
+    estimatedTravelFee: v.optional(v.number()),
+  },
+  returns: v.id("outOfAreaRequests"),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const requestId = await ctx.db.insert("outOfAreaRequests", {
+      customerName: args.name.trim(),
+      customerEmail: normalizeEmail(args.email),
+      customerPhone: args.phone.trim(),
+      smsOptIn: args.smsOptIn,
+      address: args.address,
+      scheduledDate: args.scheduledDate,
+      scheduledTime: args.scheduledTime,
+      vehicle: args.vehicle,
+      estimatedDistanceMiles: args.estimatedDistanceMiles,
+      estimatedTravelFee: args.estimatedTravelFee,
+      status: "new",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.emails.sendAdminOutOfAreaRequestNotification,
+      { requestId },
+    );
+
+    return requestId;
+  },
+});
+
+export const listOutOfAreaRequestsForAdmin = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireAdmin(ctx);
+
+    const requests = await ctx.db.query("outOfAreaRequests").collect();
+    return requests.sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+export const getOutOfAreaRequestCount = query({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    await requireAdmin(ctx);
+
+    const requests = await ctx.db
+      .query("outOfAreaRequests")
+      .withIndex("by_status", (q) => q.eq("status", "new"))
+      .collect();
+    return requests.length;
+  },
+});
+
+export const updateOutOfAreaRequestStatus = mutation({
+  args: {
+    requestId: v.id("outOfAreaRequests"),
+    status: outOfAreaRequestStatusValidator,
+    adminNotes: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    await ctx.db.patch(args.requestId, {
+      status: args.status,
+      adminNotes: args.adminNotes,
+      updatedAt: Date.now(),
+    });
+
+    return null;
+  },
+});
+
+export const getOutOfAreaRequestInternal = internalQuery({
+  args: {
+    requestId: v.id("outOfAreaRequests"),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.requestId);
   },
 });

--- a/convex/emails.tsx
+++ b/convex/emails.tsx
@@ -143,6 +143,15 @@ function escapeIcsText(value: string): string {
     .replace(/;/g, "\\;");
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function addMinutesToDate(date: string, time: string, minutes: number): string {
   const [year, month, day] = date.split("-").map(Number);
   const [hours, mins] = time.split(":").map(Number);
@@ -784,7 +793,7 @@ export const sendAdminAppointmentNotification = internalAction({
 
     const serviceNames = await getServiceNames(ctx, appointment.serviceIds);
 
-    const actionText =
+    let actionText =
       args.action === "created"
         ? "New Appointment Booked"
         : args.action === "confirmed"
@@ -798,6 +807,10 @@ export const sendAdminAppointmentNotification = internalAction({
                 : args.action === "started"
                   ? "Appointment Started"
                   : "Appointment Completed";
+
+    if (appointment.location.state?.trim().toUpperCase() !== "AR" && args.action === "created") {
+      actionText = "⚠️ OUT-OF-STATE Booking (Review Required)";
+    }
 
     const formattedTime = formatTime12h(appointment.scheduledTime);
 
@@ -848,6 +861,75 @@ export const sendAdminAppointmentNotification = internalAction({
       subject: `${actionText} - ${appointment.scheduledDate} ${formattedTime}`,
       html,
       attachments: attachment,
+    });
+  },
+});
+
+export const sendAdminOutOfAreaRequestNotification = internalAction({
+  args: {
+    requestId: v.id("outOfAreaRequests"),
+  },
+  handler: async (ctx, args) => {
+    if (shouldSkipEmails()) return;
+
+    const request = await ctx.runQuery(
+      internal.bookingDrafts.getOutOfAreaRequestInternal,
+      { requestId: args.requestId },
+    );
+    if (!request) return;
+
+    const businessInfo = await getBusinessAndFromName(ctx);
+    if (!businessInfo) return;
+
+    const formattedTime = request.scheduledTime
+      ? formatTime12h(request.scheduledTime)
+      : "No time selected";
+    const vehicleLabel = request.vehicle
+      ? [
+          request.vehicle.year,
+          request.vehicle.make,
+          request.vehicle.model,
+        ]
+          .filter(Boolean)
+          .join(" ") || "Vehicle details pending"
+      : "Vehicle details pending";
+    const location = formatLocation(request.address);
+    const estimatedTravelFee =
+      request.estimatedTravelFee !== undefined
+        ? `$${request.estimatedTravelFee.toFixed(2)}`
+        : "Unavailable";
+    const estimatedDistance =
+      request.estimatedDistanceMiles !== undefined
+        ? `${request.estimatedDistanceMiles.toFixed(1)} miles`
+        : "Unavailable";
+
+    const html = `
+      <div style="font-family: Arial, sans-serif; color: #111827; line-height: 1.5;">
+        <h2 style="margin: 0 0 12px;">Out-of-area review request</h2>
+        <p style="margin: 0 0 16px;">A customer requested manual review for service outside the regular area.</p>
+        <table style="border-collapse: collapse; width: 100%; max-width: 680px;">
+          <tbody>
+            <tr><td style="padding: 8px; font-weight: 700;">Customer</td><td style="padding: 8px;">${escapeHtml(request.customerName)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Email</td><td style="padding: 8px;">${escapeHtml(request.customerEmail)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Phone</td><td style="padding: 8px;">${escapeHtml(request.customerPhone)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Requested date</td><td style="padding: 8px;">${escapeHtml(request.scheduledDate || "No date selected")} ${escapeHtml(formattedTime)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Location</td><td style="padding: 8px;">${escapeHtml(location)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Vehicle</td><td style="padding: 8px;">${escapeHtml(vehicleLabel)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Distance</td><td style="padding: 8px;">${escapeHtml(estimatedDistance)}</td></tr>
+            <tr><td style="padding: 8px; font-weight: 700;">Travel fee</td><td style="padding: 8px;">${escapeHtml(estimatedTravelFee)}</td></tr>
+          </tbody>
+        </table>
+        <p style="margin-top: 16px;">
+          <a href="${siteUrl()}/admin/out-of-area" style="color: #0f766e; font-weight: 700;">Review requests in admin</a>
+        </p>
+      </div>
+    `;
+
+    await sendEmailMessage(ctx, {
+      from: businessInfo.from,
+      to: await getPrimaryAdminRecipient(ctx),
+      subject: `Out-of-area request - ${request.customerName}`,
+      html,
     });
   },
 });

--- a/convex/lib/travelFees.ts
+++ b/convex/lib/travelFees.ts
@@ -1,8 +1,26 @@
-const FIRST_TRAVEL_FEE_MILES = 25;
-const TRAVEL_FEE_BAND_MILES = 50;
-const BASE_TRAVEL_FEE = 40;
+export function calculateHaversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const R = 3958.8; // Earth's radius in miles
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
 
 export function calculateTravelFeeForMiles(distanceMiles: number) {
-  if (distanceMiles < FIRST_TRAVEL_FEE_MILES) return 0;
-  return (Math.floor(distanceMiles / TRAVEL_FEE_BAND_MILES) + 1) * BASE_TRAVEL_FEE;
+  if (distanceMiles < 25) return 0;
+  if (distanceMiles <= 35) return 30;
+  if (distanceMiles <= 50) return 50;
+  const fee = distanceMiles * 0.75;
+  return Math.round(fee * 100) / 100;
 }

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -436,7 +436,7 @@ describe("payments", () => {
     );
   });
 
-  test("booking draft includes the scalable Radar travel fee", async () => {
+  test("booking draft includes the tiered geodesic travel fee", async () => {
     const t = convexTest(schema, modules);
     await seedBookingSetup(t, {
       includeBookableService: false,
@@ -458,12 +458,7 @@ describe("payments", () => {
       vi.fn(async (url: string | URL, options?: RequestInit) => {
         if (String(url).includes("/geocode/forward")) {
           return Response.json({
-            addresses: [{ latitude: 34.75, longitude: -92.3 }],
-          });
-        }
-        if (String(url).includes("/route/distance")) {
-          return Response.json({
-            routes: { car: { distance: { text: "100 mi", value: 100 } } },
+            addresses: [{ latitude: 35.752258, longitude: -92.329768 }],
           });
         }
         return stripeFetchMock(url, options);
@@ -487,18 +482,19 @@ describe("payments", () => {
     });
     const draft = await t.run(async (ctx: any) => await ctx.db.get(booking.draftId));
 
-    expect(booking).toMatchObject({ travelDistanceMiles: 100, travelFee: 120 });
-    expect(draft).toMatchObject({
-      totalPrice: 240,
-      travelDistanceMiles: 100,
-      travelFee: 120,
-    });
+    expect(booking.travelDistanceMiles).toBeGreaterThan(68);
+    expect(booking.travelDistanceMiles).toBeLessThan(70);
+    expect(booking.travelFee).toBe(51.83);
+    expect(draft?.totalPrice).toBeCloseTo(171.83, 2);
+    expect(draft?.travelFee).toBe(51.83);
+    expect(draft?.travelDistanceMiles).toBeGreaterThan(68);
+    expect(draft?.travelDistanceMiles).toBeLessThan(70);
     expect(draft?.priceSnapshot).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemType: "travel_fee",
-          unitPrice: 120,
-          totalPrice: 120,
+          unitPrice: 51.83,
+          totalPrice: 51.83,
         }),
       ]),
     );

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -279,6 +279,8 @@ const schema = defineSchema({
       state: v.string(),
       zip: v.string(),
       notes: v.optional(v.string()),
+      latitude: v.optional(v.number()),
+      longitude: v.optional(v.number()),
     }),
     existingVehicleIds: v.array(v.id("vehicles")),
     existingVehicleServices: v.optional(
@@ -678,6 +680,79 @@ const schema = defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index("by_dedupe_key", ["dedupeKey"]),
+
+  outOfAreaLeads: defineTable({
+    email: v.string(),
+    address: v.string(),
+    latitude: v.optional(v.number()),
+    longitude: v.optional(v.number()),
+    createdAt: v.number(),
+  }),
+
+  outOfAreaRequests: defineTable({
+    customerName: v.string(),
+    customerEmail: v.string(),
+    customerPhone: v.string(),
+    smsOptIn: v.optional(v.boolean()),
+    address: v.object({
+      street: v.string(),
+      city: v.string(),
+      state: v.string(),
+      zip: v.string(),
+      notes: v.optional(v.string()),
+      latitude: v.optional(v.number()),
+      longitude: v.optional(v.number()),
+    }),
+    scheduledDate: v.optional(v.string()),
+    scheduledTime: v.optional(v.string()),
+    vehicle: v.optional(
+      v.object({
+        year: v.optional(v.number()),
+        make: v.optional(v.string()),
+        model: v.optional(v.string()),
+        size: v.optional(
+          v.union(v.literal("small"), v.literal("medium"), v.literal("large")),
+        ),
+        vehicleTypeId: v.optional(v.id("vehicleTypes")),
+        vehicleTypeName: v.optional(v.string()),
+        classification: v.optional(
+          v.object({
+            source: v.union(
+              v.literal("fuelEconomy"),
+              v.literal("vpic"),
+              v.literal("manual"),
+              v.literal("fallback"),
+            ),
+            confidence: v.union(
+              v.literal("high"),
+              v.literal("medium"),
+              v.literal("low"),
+            ),
+            rawCategory: v.optional(v.string()),
+            needsAdminReview: v.boolean(),
+          }),
+        ),
+        color: v.optional(v.string()),
+        licensePlate: v.optional(v.string()),
+        hasPet: v.optional(v.boolean()),
+      }),
+    ),
+    estimatedDistanceMiles: v.optional(v.number()),
+    estimatedTravelFee: v.optional(v.number()),
+    status: v.union(
+      v.literal("new"),
+      v.literal("reviewing"),
+      v.literal("contacted"),
+      v.literal("approved"),
+      v.literal("declined"),
+      v.literal("notified"),
+    ),
+    adminNotes: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_status", ["status"])
+    .index("by_created_at", ["createdAt"]),
 
   bookingClaims: defineTable({
     token: v.string(),

--- a/convex/travelFees.test.ts
+++ b/convex/travelFees.test.ts
@@ -1,7 +1,10 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api";
-import { calculateTravelFeeForMiles } from "./lib/travelFees";
+import {
+  calculateHaversineDistance,
+  calculateTravelFeeForMiles,
+} from "./lib/travelFees";
 import schema from "./schema";
 import { modules, stripeFetchMock } from "./test.setup";
 
@@ -10,29 +13,60 @@ describe("travelFees", () => {
     vi.stubGlobal("fetch", vi.fn(stripeFetchMock));
   });
 
-  test("adds $40 for each distance band after 25 miles", () => {
+  test("uses tiered fees for estimated travel distance", () => {
     expect(calculateTravelFeeForMiles(24.9)).toBe(0);
-    expect(calculateTravelFeeForMiles(25)).toBe(40);
-    expect(calculateTravelFeeForMiles(49.9)).toBe(40);
-    expect(calculateTravelFeeForMiles(50)).toBe(80);
-    expect(calculateTravelFeeForMiles(99.9)).toBe(80);
-    expect(calculateTravelFeeForMiles(100)).toBe(120);
-    expect(calculateTravelFeeForMiles(150)).toBe(160);
+    expect(calculateTravelFeeForMiles(25)).toBe(30);
+    expect(calculateTravelFeeForMiles(35)).toBe(30);
+    expect(calculateTravelFeeForMiles(35.1)).toBe(50);
+    expect(calculateTravelFeeForMiles(50)).toBe(50);
+    expect(calculateTravelFeeForMiles(50.1)).toBe(37.58);
+    expect(calculateTravelFeeForMiles(100)).toBe(75);
   });
 
-  test("calculates route distance with Radar and returns the matching fee", async () => {
+  test("calculates haversine distance in miles", () => {
+    const distance = calculateHaversineDistance(
+      34.752258,
+      -92.329768,
+      35.752258,
+      -92.329768,
+    );
+
+    expect(distance).toBeGreaterThan(68);
+    expect(distance).toBeLessThan(70);
+  });
+
+  test("uses passed coordinates before geocoding", async () => {
+    const t = convexTest(schema, modules);
+    const fetchMock = vi.fn(stripeFetchMock);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await t.action(api.travelFees.calculate, {
+      address: {
+        street: "100 Far Away Rd",
+        city: "Somewhere",
+        state: "AR",
+        zip: "72000",
+        latitude: 35.752258,
+        longitude: -92.329768,
+      },
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.distanceMiles).toBeGreaterThan(68);
+    expect(result.distanceMiles).toBeLessThan(70);
+    expect(result.fee).toBe(calculateTravelFeeForMiles(result.distanceMiles));
+  });
+
+  test("falls back to Radar geocoding when coordinates are missing", async () => {
+    const previousKey = process.env.RADAR_SECRET_KEY;
+    process.env.RADAR_SECRET_KEY = "test_radar_key";
     const t = convexTest(schema, modules);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string | URL) => {
         if (String(url).includes("/geocode/forward")) {
           return Response.json({
-            addresses: [{ latitude: 34.75, longitude: -92.3 }],
-          });
-        }
-        if (String(url).includes("/route/distance")) {
-          return Response.json({
-            routes: { car: { distance: { text: "100 mi", value: 100 } } },
+            addresses: [{ latitude: 34.752258, longitude: -92.329768 }],
           });
         }
         return Response.json({}, { status: 404 });
@@ -41,13 +75,14 @@ describe("travelFees", () => {
 
     const result = await t.action(api.travelFees.calculate, {
       address: {
-        street: "100 Far Away Rd",
-        city: "Somewhere",
+        street: "220 N Tyler St",
+        city: "Little Rock",
         state: "AR",
-        zip: "72000",
+        zip: "72205",
       },
     });
 
-    expect(result).toEqual({ distanceMiles: 100, fee: 120 });
+    process.env.RADAR_SECRET_KEY = previousKey;
+    expect(result).toEqual({ distanceMiles: 0, fee: 0 });
   });
 });

--- a/convex/travelFees.ts
+++ b/convex/travelFees.ts
@@ -1,8 +1,9 @@
 import { ConvexError, v } from "convex/values";
 import { action } from "./_generated/server";
-import { calculateTravelFeeForMiles } from "./lib/travelFees";
+import { calculateTravelFeeForMiles, calculateHaversineDistance } from "./lib/travelFees";
 
-const TRAVEL_ORIGIN_ADDRESS = "220 N Tyler St, Little Rock, AR 72205";
+const ORIGIN_LAT = 34.752258;
+const ORIGIN_LNG = -92.329768;
 
 const addressValidator = v.object({
   street: v.string(),
@@ -10,28 +11,12 @@ const addressValidator = v.object({
   state: v.string(),
   zip: v.string(),
   notes: v.optional(v.string()),
+  latitude: v.optional(v.number()),
+  longitude: v.optional(v.number()),
 });
 
 function roundMiles(value: number) {
   return Math.round(value * 10) / 10;
-}
-
-function milesFromDistance(distance: any): number {
-  if (!distance) return 0;
-  if (typeof distance.text === "string") {
-    const text = distance.text.toLowerCase();
-    const numeric = Number.parseFloat(text.replace(/[^0-9.]/g, ""));
-    if (Number.isFinite(numeric)) {
-      if (text.includes("mi")) return numeric;
-      if (text.includes("ft")) return numeric / 5280;
-      if (text.includes("km")) return numeric / 1.60934;
-      if (text.includes("m")) return numeric / 1609.34;
-    }
-  }
-  if (typeof distance.value === "number" && Number.isFinite(distance.value)) {
-    return distance.value > 1000 ? distance.value / 1609.34 : distance.value;
-  }
-  return 0;
 }
 
 async function geocodeAddress(address: string, radarSecretKey: string) {
@@ -70,42 +55,34 @@ export const calculate = action({
     fee: v.number(),
   }),
   handler: async (_ctx, args) => {
-    const radarSecretKey = process.env.RADAR_SECRET_KEY;
-    if (!radarSecretKey) {
-      throw new ConvexError({
-        code: "MISSING_RADAR_SECRET_KEY",
-        message: "Travel distance calculation is temporarily unavailable.",
-      });
+    let lat = args.address.latitude;
+    let lng = args.address.longitude;
+
+    if (lat === undefined || lng === undefined) {
+      const radarSecretKey = process.env.RADAR_SECRET_KEY;
+      if (!radarSecretKey) {
+        throw new ConvexError({
+          code: "MISSING_RADAR_SECRET_KEY",
+          message: "Travel distance calculation is temporarily unavailable.",
+        });
+      }
+
+      const destinationAddress = [
+        args.address.street,
+        args.address.city,
+        args.address.state,
+        args.address.zip,
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+      const destCoords = await geocodeAddress(destinationAddress, radarSecretKey);
+      lat = destCoords.latitude;
+      lng = destCoords.longitude;
     }
 
-    const destinationAddress = [
-      args.address.street,
-      args.address.city,
-      args.address.state,
-      args.address.zip,
-    ]
-      .filter(Boolean)
-      .join(", ");
-    const [origin, destination] = await Promise.all([
-      geocodeAddress(TRAVEL_ORIGIN_ADDRESS, radarSecretKey),
-      geocodeAddress(destinationAddress, radarSecretKey),
-    ]);
-    const routeResponse = await fetch(
-      `https://api.radar.io/v1/route/distance?origin=${origin.latitude},${origin.longitude}&destination=${destination.latitude},${destination.longitude}&modes=car&units=imperial`,
-      {
-        headers: { Authorization: radarSecretKey },
-      },
-    );
-    if (!routeResponse.ok) {
-      throw new ConvexError({
-        code: "RADAR_ROUTE_FAILED",
-        message: "We could not calculate travel distance for this address.",
-      });
-    }
+    const distanceMiles = roundMiles(calculateHaversineDistance(ORIGIN_LAT, ORIGIN_LNG, lat, lng));
 
-    const routePayload: any = await routeResponse.json();
-    const route = routePayload.routes?.car || routePayload.routes?.geodesic;
-    const distanceMiles = roundMiles(milesFromDistance(route?.distance));
     return {
       distanceMiles,
       fee: calculateTravelFeeForMiles(distanceMiles),

--- a/hooks/use-booking-store.ts
+++ b/hooks/use-booking-store.ts
@@ -36,6 +36,8 @@ interface Step1Data {
   state: string
   zip?: string
   locationNotes?: string
+  latitude?: number
+  longitude?: number
 }
 
 interface Step2Data {


### PR DESCRIPTION
## Summary

- Shows deposit due today and remaining balance in the booking order summary using deposit settings from Convex.
- Updates travel fee calculation to the expanded tier model using geodesic distance from River City MD HQ.
- Adds out-of-area request handling on /book so non-AR customers can request manual review or join the notify list without entering checkout.
- Adds an admin out-of-area request queue with status management and email notification for review requests.

## Implementation Notes

- Out-of-area review requests are stored separately from notify-only leads so admins can prioritize high-intent requests.
- Coordinate-based travel fees use selected address latitude/longitude and fall back to Radar geocoding when coordinates are unavailable.
- The out-of-area booking path ends after request submission and does not collect deposit/full payment before admin review.

## Testing Notes

- pnpm exec convex codegen
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test:once
- pnpm build

Closes #59