### PR TITLE
chore: add Convex rate limiting for public workflows

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -33,6 +33,7 @@ import type * as notifications from "../notifications.js";
 import type * as payments from "../payments.js";
 import type * as petFeeSettings from "../petFeeSettings.js";
 import type * as r2 from "../r2.js";
+import type * as rateLimiter from "../rateLimiter.js";
 import type * as reviews from "../reviews.js";
 import type * as services from "../services.js";
 import type * as setupReadiness from "../setupReadiness.js";
@@ -81,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   payments: typeof payments;
   petFeeSettings: typeof petFeeSettings;
   r2: typeof r2;
+  rateLimiter: typeof rateLimiter;
   reviews: typeof reviews;
   services: typeof services;
   setupReadiness: typeof setupReadiness;
@@ -131,4 +133,5 @@ export declare const components: {
   twilio: import("@convex-dev/twilio/_generated/component.js").ComponentApi<"twilio">;
   stripe: import("@convex-dev/stripe/_generated/component.js").ComponentApi<"stripe">;
   r2: import("@convex-dev/r2/_generated/component.js").ComponentApi<"r2">;
+  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
 };

--- a/convex/bookingClaims.ts
+++ b/convex/bookingClaims.ts
@@ -1,6 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { internalMutation, mutation, query } from "./_generated/server";
 import { getNormalizedIdentityEmail, getUserIdFromIdentity } from "./auth";
+import { assertRateLimit } from "./rateLimiter";
 
 const BOOKING_CLAIM_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 
@@ -110,6 +111,11 @@ export const claim = mutation({
     if (!identity?.subject) {
       throw new ConvexError("You need to sign in before claiming this booking.");
     }
+
+    await assertRateLimit(ctx, "bookingClaimByUser", {
+      key: `user:${identity.subject}`,
+      message: "Too many booking claim attempts. Please try again later.",
+    });
 
     const claim = await ctx.db
       .query("bookingClaims")

--- a/convex/bookingDrafts.test.ts
+++ b/convex/bookingDrafts.test.ts
@@ -54,4 +54,19 @@ describe("bookingDrafts out-of-area requests", () => {
       },
     });
   });
+
+  test("rate limits repeated out-of-area leads for the same email", async () => {
+    const t = convexTest(schema, modules);
+    const payload = {
+      email: "repeat@example.com",
+      address: "New York, NY",
+    };
+
+    await t.mutation(api.bookingDrafts.saveOutOfAreaLead, payload);
+    await t.mutation(api.bookingDrafts.saveOutOfAreaLead, payload);
+
+    await expect(
+      t.mutation(api.bookingDrafts.saveOutOfAreaLead, payload),
+    ).rejects.toThrow(/RATE_LIMITED|several requests/i);
+  });
 });

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -25,6 +25,7 @@ import {
   getEffectiveServicePrice,
   type VehicleSize,
 } from "./lib/pricing";
+import { assertRateLimit, contactRateLimitKey } from "./rateLimiter";
 
 const HOLD_DURATION_MS = 15 * 60 * 1000;
 const ABANDONED_EMAIL_DELAY_MS = 60 * 60 * 1000;
@@ -734,6 +735,11 @@ export const createOrUpdate = action({
     travelDistanceMiles: number;
     travelFee: number;
   }> => {
+    await assertRateLimit(ctx, "bookingDraftByEmail", {
+      key: contactRateLimitKey({ email: args.email, phone: args.phone }),
+      message: "Too many booking attempts. Please wait a bit and try again.",
+    });
+
     const travel = await ctx.runAction(api.travelFees.calculate, {
       address: args.address,
     });
@@ -758,7 +764,11 @@ export const createBeforePhotoUploadUrl = mutation({
     key: v.string(),
     url: v.string(),
   }),
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
+    await assertRateLimit(ctx, "beforePhotoUploadGlobal", {
+      message: "Photo uploads are temporarily busy. Please try again shortly.",
+    });
+
     validateBeforePhotoFile(args.fileName, args.contentType);
     const sanitizedFileName = args.fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
     const key = `booking-before-photos/${Date.now()}-${crypto.randomUUID()}-${sanitizedFileName}`;
@@ -1546,6 +1556,11 @@ export const saveOutOfAreaLead = mutation({
   },
   returns: v.id("outOfAreaLeads"),
   handler: async (ctx, args) => {
+    await assertRateLimit(ctx, "outOfAreaLeadByEmail", {
+      key: contactRateLimitKey({ email: args.email }),
+      message: "We received several requests for this email. Please try again later.",
+    });
+
     return await ctx.db.insert("outOfAreaLeads", {
       email: args.email,
       address: args.address,
@@ -1571,6 +1586,11 @@ export const saveOutOfAreaRequest = mutation({
   },
   returns: v.id("outOfAreaRequests"),
   handler: async (ctx, args) => {
+    await assertRateLimit(ctx, "outOfAreaRequestByContact", {
+      key: contactRateLimitKey({ email: args.email, phone: args.phone }),
+      message: "We received several review requests from this contact. Please try again later.",
+    });
+
     const now = Date.now();
     const requestId = await ctx.db.insert("outOfAreaRequests", {
       customerName: args.name.trim(),

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { getUserIdFromIdentity, isAdmin } from "./auth";
+import { assertRateLimit } from "./rateLimiter";
 
 export const list = query({
   args: {
@@ -38,6 +39,11 @@ export const send = mutation({
     if (!isAdminUser && authUserId !== args.userId) {
       throw new Error("Access denied");
     }
+
+    await assertRateLimit(ctx, "chatSendByUser", {
+      key: String(authUserId),
+      message: "You're sending messages too quickly. Please wait a moment.",
+    });
 
     await ctx.db.insert("chatMessages", {
       userId: args.userId,

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -5,6 +5,7 @@ import stripe from "@convex-dev/stripe/convex.config.js";
 import workpool from "@convex-dev/workpool/convex.config.js";
 import twilio from "@convex-dev/twilio/convex.config.js";
 import r2 from "@convex-dev/r2/convex.config.js";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config.js";
 
 const app = defineApp();
 app.use(resend);
@@ -13,5 +14,6 @@ app.use(workpool, { name: "notificationsWorkpool" });
 app.use(twilio);
 app.use(stripe);
 app.use(r2, { name: "r2" });
+app.use(rateLimiter);
 
 export default app;

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -12,6 +12,7 @@ import { api, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { stripeClient } from "./stripeClient";
 import { BOOKING_BLOCK_MINUTES } from "./lib/booking";
+import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
 const paymentsInternal: any = (internal as any).payments;
 const STRIPE_API_MAX_ATTEMPTS = 3;
@@ -2481,6 +2482,11 @@ export const createBookingCheckout = action({
     token: v.string(),
   }),
   handler: async (ctx, args): Promise<BookingCheckoutResult> => {
+    await assertRateLimit(ctx, "bookingCheckoutByDraft", {
+      key: String(args.draftId),
+      message: "Checkout is temporarily busy for this booking. Please try again shortly.",
+    });
+
     const draft: Doc<"bookingDrafts"> | null = await ctx.runQuery(
       internal.bookingDrafts.getByIdInternal,
       {
@@ -2512,6 +2518,11 @@ export const resumeBookingDraftCheckout = action({
     ctx,
     args,
   ): Promise<ResumeBookingDraftCheckoutResult> => {
+    await assertRateLimit(ctx, "bookingCheckoutByDraft", {
+      key: normalizeRateLimitKey(args.token),
+      message: "Checkout is temporarily busy for this booking. Please try again shortly.",
+    });
+
     const draft: Doc<"bookingDrafts"> | null = await ctx.runQuery(
       internal.bookingDrafts.getByTokenInternal,
       {

--- a/convex/rateLimiter.ts
+++ b/convex/rateLimiter.ts
@@ -1,0 +1,141 @@
+import { ConvexError } from "convex/values";
+import { HOUR, MINUTE, RateLimiter } from "@convex-dev/rate-limiter";
+import { components } from "./_generated/api";
+
+export const rateLimiter = new RateLimiter(components.rateLimiter, {
+  travelFeeGlobal: {
+    kind: "token bucket",
+    rate: 240,
+    period: MINUTE,
+    capacity: 120,
+    shards: 8,
+  },
+  travelFeeByAddress: {
+    kind: "token bucket",
+    rate: 20,
+    period: MINUTE,
+    capacity: 10,
+  },
+  vehicleLookupGlobal: {
+    kind: "token bucket",
+    rate: 120,
+    period: MINUTE,
+    capacity: 60,
+    shards: 6,
+  },
+  vehicleLookupByQuery: {
+    kind: "token bucket",
+    rate: 20,
+    period: MINUTE,
+    capacity: 10,
+  },
+  bookingDraftByEmail: {
+    kind: "token bucket",
+    rate: 8,
+    period: HOUR,
+    capacity: 4,
+  },
+  bookingCheckoutByDraft: {
+    kind: "token bucket",
+    rate: 8,
+    period: MINUTE,
+    capacity: 4,
+  },
+  bookingClaimByUser: {
+    kind: "token bucket",
+    rate: 10,
+    period: HOUR,
+    capacity: 5,
+  },
+  outOfAreaLeadByEmail: {
+    kind: "token bucket",
+    rate: 4,
+    period: HOUR,
+    capacity: 2,
+  },
+  outOfAreaRequestByContact: {
+    kind: "token bucket",
+    rate: 4,
+    period: HOUR,
+    capacity: 2,
+  },
+  beforePhotoUploadGlobal: {
+    kind: "token bucket",
+    rate: 120,
+    period: MINUTE,
+    capacity: 60,
+    shards: 6,
+  },
+  reviewSubmitByAppointment: {
+    kind: "token bucket",
+    rate: 3,
+    period: HOUR,
+    capacity: 1,
+  },
+  userProfileByUser: {
+    kind: "token bucket",
+    rate: 10,
+    period: HOUR,
+    capacity: 3,
+  },
+  chatSendByUser: {
+    kind: "token bucket",
+    rate: 30,
+    period: MINUTE,
+    capacity: 10,
+  },
+});
+
+export type RateLimitName = keyof NonNullable<typeof rateLimiter.limits>;
+
+export function normalizeRateLimitKey(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ").slice(0, 256);
+}
+
+export function contactRateLimitKey(args: {
+  email?: string;
+  phone?: string;
+  fallback?: string;
+}) {
+  const email = args.email?.trim();
+  if (email) return `email:${normalizeRateLimitKey(email)}`;
+  const phone = args.phone?.replace(/\D/g, "");
+  if (phone) return `phone:${phone.slice(-12)}`;
+  return normalizeRateLimitKey(args.fallback || "anonymous");
+}
+
+export async function identityRateLimitKey(
+  ctx: { auth: { getUserIdentity: () => Promise<{ subject?: string } | null> } },
+  fallback: string,
+) {
+  const identity = await ctx.auth.getUserIdentity();
+  return identity?.subject
+    ? `user:${identity.subject}`
+    : `anon:${normalizeRateLimitKey(fallback)}`;
+}
+
+export async function assertRateLimit(
+  ctx: Parameters<typeof rateLimiter.limit>[0],
+  name: RateLimitName,
+  options?: {
+    key?: string;
+    count?: number;
+    message?: string;
+  },
+) {
+  const status = await rateLimiter.limit(ctx, name, {
+    key: options?.key,
+    count: options?.count,
+  });
+
+  if (!status.ok) {
+    throw new ConvexError({
+      code: "RATE_LIMITED",
+      message:
+        options?.message ||
+        "Too many attempts. Please wait a moment and try again.",
+      retryAfter: status.retryAfter,
+      limit: name,
+    });
+  }
+}

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -2,6 +2,7 @@ import { query, mutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 import { getUserIdFromIdentity, requireAdmin, isAdmin } from "./auth";
 import { internal } from "./_generated/api";
+import { assertRateLimit } from "./rateLimiter";
 
 function shouldScheduleNotificationJobs(): boolean {
   return process.env.CONVEX_TEST !== "true" && process.env.NODE_ENV !== "test";
@@ -312,6 +313,11 @@ export const submit = mutation({
     isPublic: v.boolean(),
   },
   handler: async (ctx, args) => {
+    await assertRateLimit(ctx, "reviewSubmitByAppointment", {
+      key: String(args.appointmentId),
+      message: "We already received recent review activity for this appointment.",
+    });
+
     const appointment = await ctx.db.get(args.appointmentId);
     if (!appointment) throw new Error("Appointment not found");
 

--- a/convex/test.setup.ts
+++ b/convex/test.setup.ts
@@ -2,6 +2,19 @@
 // This file configures the test environment globally
 
 import { vi } from "vitest";
+import rateLimiterTest from "@convex-dev/rate-limiter/test";
+
+vi.mock("convex-test", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("convex-test")>();
+  return {
+    ...actual,
+    convexTest: (...args: Parameters<typeof actual.convexTest>) => {
+      const t = actual.convexTest(...args);
+      rateLimiterTest.register(t);
+      return t;
+    },
+  };
+});
 
 // Set Stripe environment variables globally for all tests
 // This ensures scheduled functions have access to the keys
@@ -154,7 +167,6 @@ declare global {
 // Glob pattern to import all Convex functions for testing.
 // Paths are relative to the convex/ directory (this file lives in convex/).
 // Vite's import.meta.glob doesn't support bash extended globbing; we match all .ts/.tsx then filter out test files.
-// @ts-expect-error - import.meta.glob is a Vite-specific feature, types may not be available
 const allModules = import.meta.glob("./**/*.{ts,tsx}", {
   eager: false,
 }) as Record<string, () => Promise<any>>;

--- a/convex/travelFees.ts
+++ b/convex/travelFees.ts
@@ -1,6 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { action } from "./_generated/server";
 import { calculateTravelFeeForMiles, calculateHaversineDistance } from "./lib/travelFees";
+import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
 const ORIGIN_LAT = 34.752258;
 const ORIGIN_LNG = -92.329768;
@@ -54,7 +55,27 @@ export const calculate = action({
     distanceMiles: v.number(),
     fee: v.number(),
   }),
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
+    const addressKey = normalizeRateLimitKey(
+      [
+        args.address.street,
+        args.address.city,
+        args.address.state,
+        args.address.zip,
+        args.address.latitude,
+        args.address.longitude,
+      ]
+        .filter((value) => value !== undefined && value !== "")
+        .join("|"),
+    );
+    await assertRateLimit(ctx, "travelFeeGlobal", {
+      message: "Travel fee estimates are temporarily busy. Please try again shortly.",
+    });
+    await assertRateLimit(ctx, "travelFeeByAddress", {
+      key: addressKey,
+      message: "Please wait a moment before recalculating this address.",
+    });
+
     let lat = args.address.latitude;
     let lng = args.address.longitude;
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -22,6 +22,7 @@ import {
   normalizeUserNotificationPreferences,
   userNotificationPreferencesValidator,
 } from "./lib/notificationSettings";
+import { assertRateLimit } from "./rateLimiter";
 
 const STRIPE_CUSTOMER_SYNC_RETRY_DELAYS_MS = [
   0,
@@ -581,6 +582,11 @@ export const createUserProfile = mutation({
     if (!identity || !identity.subject) {
       throw new Error("Not authenticated");
     }
+
+    await assertRateLimit(ctx, "userProfileByUser", {
+      key: `user:${identity.subject}`,
+      message: "Too many profile setup attempts. Please try again later.",
+    });
 
     // Get Clerk user ID from identity (needed for user creation and updates)
     const clerkUserId = identity.subject;

--- a/convex/vehicleTypes.ts
+++ b/convex/vehicleTypes.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { requireAdmin } from "./auth";
 import type { VehicleSize } from "./lib/pricing";
+import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
 const legacySizeValidator = v.union(
   v.literal("small"),
@@ -338,7 +339,7 @@ export const searchModels = action({
     query: v.string(),
   },
   handler: async (
-    _ctx,
+    ctx,
     args,
   ): Promise<
     Array<{
@@ -350,6 +351,14 @@ export const searchModels = action({
     }>
   > => {
     const normalizedQuery = args.query.trim().replace(/\s+/g, " ");
+    await assertRateLimit(ctx, "vehicleLookupGlobal", {
+      message: "Vehicle lookup is temporarily busy. Please try again shortly.",
+    });
+    await assertRateLimit(ctx, "vehicleLookupByQuery", {
+      key: normalizeRateLimitKey(normalizedQuery),
+      message: "Please wait a moment before searching for that vehicle again.",
+    });
+
     const yearMatch = normalizedQuery.match(/\b(19|20)\d{2}\b/);
     const year = yearMatch ? Number(yearMatch[0]) : undefined;
     const vehicleQuery = normalizedQuery
@@ -437,6 +446,14 @@ export const classify = action({
     rawCategory?: string;
     needsAdminReview: boolean;
   }> => {
+    await assertRateLimit(ctx, "vehicleLookupGlobal", {
+      message: "Vehicle lookup is temporarily busy. Please try again shortly.",
+    });
+    await assertRateLimit(ctx, "vehicleLookupByQuery", {
+      key: normalizeRateLimitKey(`${args.year} ${args.make} ${args.model}`),
+      message: "Please wait a moment before classifying that vehicle again.",
+    });
+
     await ctx.runMutation(internal.vehicleTypes.ensureDefaultsInternal, {});
 
     const make = encodeURIComponent(args.make.trim());

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@clerk/backend": "^2.29.0",
     "@clerk/nextjs": "^6.36.5",
     "@convex-dev/r2": "^0.9.1",
+    "@convex-dev/rate-limiter": "^0.3.2",
     "@convex-dev/resend": "^0.2.3",
     "@convex-dev/stripe": "^0.1.3",
     "@convex-dev/twilio": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@convex-dev/r2':
         specifier: ^0.9.1
         version: 0.9.1(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.2.1)
+      '@convex-dev/rate-limiter':
+        specifier: ^0.3.2
+        version: 0.3.2(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@convex-dev/resend':
         specifier: ^0.2.3
         version: 0.2.3(@react-email/render@2.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.2.1))(convex@1.40.0(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -1146,105 +1149,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1372,56 +1359,48 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@16.1.1':
     resolution: {integrity: sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.0.10':
     resolution: {integrity: sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.0.10':
     resolution: {integrity: sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.0.10':
     resolution: {integrity: sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.0.10':
     resolution: {integrity: sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==}
@@ -2395,67 +2374,56 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -2771,28 +2739,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3016,49 +2980,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4347,28 +4303,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -9373,7 +9325,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9395,7 +9347,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

- Adds the `@convex-dev/rate-limiter` component and mounts it in the Convex app config.
- Defines shared token-bucket limits for high-risk public and authenticated workflows.
- Applies keyed limits to travel fee estimates, vehicle lookups/classification, booking draft creation, checkout resume/create, booking claims, out-of-area leads/requests, before-photo upload URL creation, review submission, profile creation, and chat sends.

## Implementation Notes

- Uses per-contact, per-address, per-query, per-booking, and per-user keys where available.
- Uses sharded global limits around higher-traffic lookup/upload paths to reduce stampede risk without making one hot key a bottleneck.
- Throws structured `ConvexError` payloads with `RATE_LIMITED`, `retryAfter`, and the limit name.
- Registers the rate limiter component in the shared Convex test setup so existing `convex-test` suites keep working.
- Adds coverage for repeated out-of-area lead submissions from the same email.

## Testing Notes

- pnpm exec convex codegen
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test:once
- pnpm build
- pnpm check (not available: no script/command defined)
- pnpm typecheck (not available: no script/command defined; used `pnpm exec tsc --noEmit`)

Closes #61