### PR TITLE
feat: curate landing page service pricing

### DIFF
--- a/components/admin/services-client.tsx
+++ b/components/admin/services-client.tsx
@@ -57,6 +57,7 @@ type ServiceRecord = {
   bookings?: number;
   popularity?: string;
   isActive: boolean;
+  showOnLandingPage?: boolean;
   categoryId?: Id<"serviceCategories">;
   includedServiceIds?: Id<"services">[];
   features?: string[];
@@ -259,6 +260,7 @@ export default function ServicesClient() {
         features: service.features,
         icon: service.icon,
         isActive: !service.isActive,
+        showOnLandingPage: service.showOnLandingPage ?? true,
       });
 
       toast.success(service.isActive ? "Service hidden" : "Service made visible");
@@ -349,9 +351,16 @@ export default function ServicesClient() {
       accessorFn: (row) => (row.isActive ? "active" : "hidden"),
       header: "Visibility",
       cell: ({ row }) => (
-        <Badge variant={row.original.isActive ? "default" : "secondary"}>
-          {row.original.isActive ? "Visible" : "Hidden"}
-        </Badge>
+        <div className="flex flex-wrap gap-1">
+          <Badge variant={row.original.isActive ? "default" : "secondary"}>
+            {row.original.isActive ? "Bookable" : "Hidden"}
+          </Badge>
+          <Badge
+            variant={row.original.showOnLandingPage !== false ? "outline" : "secondary"}
+          >
+            {row.original.showOnLandingPage !== false ? "Landing" : "No landing"}
+          </Badge>
+        </div>
       ),
     },
     {

--- a/components/forms/admin/service-editor.tsx
+++ b/components/forms/admin/service-editor.tsx
@@ -51,6 +51,7 @@ const formSchema = z
     icon: z.string().optional(),
     includedServiceIds: z.array(z.string()).optional(),
     isActive: z.boolean(),
+    showOnLandingPage: z.boolean(),
   })
   .refine(
     (data) =>
@@ -107,6 +108,7 @@ export function ServiceEditor({
       icon: "",
       includedServiceIds: [],
       isActive: true,
+      showOnLandingPage: true,
     },
   });
 
@@ -127,6 +129,7 @@ export function ServiceEditor({
       icon: service.icon ?? "",
       includedServiceIds: service.includedServiceIds?.map(String) ?? [],
       isActive: service.isActive,
+      showOnLandingPage: service.showOnLandingPage ?? true,
     });
   }, [form, service]);
 
@@ -179,6 +182,7 @@ export function ServiceEditor({
           features: data.features,
           icon: data.icon,
           isActive: data.isActive,
+          showOnLandingPage: data.showOnLandingPage,
         });
         toast.success("Service updated");
       } else {
@@ -194,6 +198,7 @@ export function ServiceEditor({
           includedServiceIds: data.includedServiceIds as Id<"services">[],
           features: data.features,
           icon: data.icon,
+          showOnLandingPage: data.showOnLandingPage,
         });
         toast.success(`${TYPE_LABELS[serviceType]} created`);
       }
@@ -357,6 +362,32 @@ export function ServiceEditor({
                     ))}
                   </div>
                 </div>
+
+                <FormField
+                  control={form.control}
+                  name="showOnLandingPage"
+                  render={({ field }) => (
+                    <FormItem>
+                      <label className="flex cursor-pointer items-start gap-3 rounded-md border p-3">
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked === true)
+                          }
+                        />
+                        <span>
+                          <span className="text-sm font-medium">
+                            Show in landing page pricing
+                          </span>
+                          <span className="mt-1 block text-xs text-muted-foreground">
+                            Include this product in the public pricing cards when
+                            it is available for the selected vehicle type.
+                          </span>
+                        </span>
+                      </label>
+                    </FormItem>
+                  )}
+                />
 
                 <FormField
                   control={form.control}

--- a/components/home/pricing.tsx
+++ b/components/home/pricing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -12,21 +12,30 @@ import { cn } from "@/lib/utils";
 
 export function PricingSection() {
   const router = useRouter();
-  const servicesQuery = useQuery(api.services.list);
+  const pricingQuery = useQuery(api.services.listLandingPagePricing);
   const bookingReadiness = useQuery(
     api.setupReadiness.getPublicBookingReadiness,
   );
 
-  const [selectedSize, setSelectedSize] = useState<
-    "small" | "medium" | "large"
-  >("medium");
+  const [selectedVehicleTypeId, setSelectedVehicleTypeId] = useState<
+    string | null
+  >(null);
 
-  const mainServices =
-    servicesQuery?.filter(
-      (service) =>
-        service.isActive &&
-        (service.serviceType === "standard" || !service.serviceType),
-    ) || [];
+  useEffect(() => {
+    if (!pricingQuery?.length) return;
+    const hasSelected = pricingQuery.some(
+      (group) => group.vehicleType._id === selectedVehicleTypeId,
+    );
+    if (!hasSelected) {
+      setSelectedVehicleTypeId(pricingQuery[0].vehicleType._id);
+    }
+  }, [pricingQuery, selectedVehicleTypeId]);
+
+  const selectedGroup =
+    pricingQuery?.find(
+      (group) => group.vehicleType._id === selectedVehicleTypeId,
+    ) ?? pricingQuery?.[0];
+  const mainServices = selectedGroup?.services ?? [];
 
   const handleBookNow = () => {
     if (bookingReadiness && !bookingReadiness.isReady) {
@@ -38,7 +47,7 @@ export function PricingSection() {
   };
 
   // Loading state
-  if (servicesQuery === undefined) {
+  if (pricingQuery === undefined) {
     return (
       <section
         id="pricing"
@@ -77,7 +86,7 @@ export function PricingSection() {
   }
 
   // Error state
-  if (servicesQuery === null) {
+  if (pricingQuery === null) {
     return (
       <section
         id="pricing"
@@ -112,14 +121,14 @@ export function PricingSection() {
               Transparent pricing for quality service
             </h2>
             <p className="text-lg text-muted-foreground mb-2">
-              Professional mobile detailing services for all vehicle sizes
+              Mobile detailing packages matched to your vehicle
             </p>
             <p className="text-sm text-muted-foreground">
-              Professional-grade products, non-toxic and eco-friendly.
+              Choose a vehicle type to see the services currently offered for it.
             </p>
           </motion.div>
 
-          {/* Vehicle Size Tabs */}
+          {/* Vehicle Type Tabs */}
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -132,28 +141,22 @@ export function PricingSection() {
             </p>
             <div
               role="tablist"
-              className="flex w-full rounded-lg border border-border/40 bg-secondary/40 p-1 gap-1"
+              className="flex w-full gap-1 overflow-x-auto rounded-lg border border-border/40 bg-secondary/40 p-1"
             >
-              {(
-                [
-                  { value: "small", label: "Small / Compact" },
-                  { value: "medium", label: "Mid-Size SUV" },
-                  { value: "large", label: "Truck / Large" },
-                ] as const
-              ).map(({ value, label }) => (
+              {pricingQuery.map(({ vehicleType }) => (
                 <button
-                  key={value}
+                  key={vehicleType._id}
                   role="tab"
-                  aria-selected={selectedSize === value}
-                  onClick={() => setSelectedSize(value)}
+                  aria-selected={selectedGroup?.vehicleType._id === vehicleType._id}
+                  onClick={() => setSelectedVehicleTypeId(vehicleType._id)}
                   className={cn(
-                    "flex-1 rounded-md py-2.5 text-xs sm:text-sm font-medium transition-colors outline-none focus-visible:outline-none",
-                    selectedSize === value
+                    "min-w-24 flex-1 rounded-md px-3 py-2.5 text-xs sm:text-sm font-medium transition-colors outline-none focus-visible:outline-none",
+                    selectedGroup?.vehicleType._id === vehicleType._id
                       ? "bg-background text-foreground"
                       : "text-muted-foreground hover:text-foreground",
                   )}
                 >
-                  {label}
+                  {vehicleType.name}
                 </button>
               ))}
             </div>
@@ -161,18 +164,22 @@ export function PricingSection() {
 
           {/* Cards */}
           <div className="max-w-6xl mx-auto">
-            <div
-              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5"
-              aria-label="Service pricing cards"
-            >
+            {mainServices.length === 0 ? (
+              <div className="mx-auto max-w-2xl rounded-xl border border-border/40 bg-background px-6 py-10 text-center">
+                <h3 className="text-lg font-semibold">
+                  Pricing is being updated
+                </h3>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Contact us or start booking to see the best options for your
+                  vehicle.
+                </p>
+              </div>
+            ) : (
+              <div
+                className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5"
+                aria-label="Service pricing cards"
+              >
               {mainServices.map((service, index) => {
-                const price =
-                  selectedSize === "small"
-                    ? service.basePriceSmall
-                    : selectedSize === "medium"
-                      ? service.basePriceMedium
-                      : service.basePriceLarge;
-
                 const usesTwoColFeatures =
                   service.features && service.features.length >= 4;
 
@@ -215,13 +222,11 @@ export function PricingSection() {
                             $
                           </span>
                           <span className="text-3xl font-bold text-foreground tracking-tight">
-                            {price?.toFixed(0) ?? "N/A"}
+                            {service.price.toFixed(0)}
                           </span>
-                          {price != null && (
-                            <span className="text-xs font-medium text-muted-foreground">
-                              .00
-                            </span>
-                          )}
+                          <span className="text-xs font-medium text-muted-foreground">
+                            .00
+                          </span>
                         </div>
                         <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-widest mt-1">
                           Approx.&nbsp;{Math.floor(service.duration / 60)}h
@@ -275,7 +280,8 @@ export function PricingSection() {
                   </motion.div>
                 );
               })}
-            </div>
+              </div>
+            )}
           </div>
 
           {/* Desktop CTA */}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -167,6 +167,7 @@ const schema = defineSchema({
     categoryId: v.optional(v.id("serviceCategories")), // legacy field
     includedServiceIds: v.optional(v.array(v.id("services"))),
     isActive: v.boolean(),
+    showOnLandingPage: v.optional(v.boolean()),
     // NEW FIELDS:
     features: v.optional(v.array(v.string())), // Service features list
     icon: v.optional(v.string()), // Emoji or icon identifier

--- a/convex/services.test.ts
+++ b/convex/services.test.ts
@@ -166,6 +166,94 @@ describe("services", () => {
     expect(vehicleTypes.some((vehicleType) => vehicleType.name === "Boat")).toBe(true);
   });
 
+  test("landing page pricing is curated and grouped by vehicle type", async () => {
+    const t = convexTest(schema, modules);
+
+    const adminId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-landing-pricing@test.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-landing-pricing@test.com",
+    });
+
+    await asAdmin.mutation(api.vehicleTypes.ensureDefaults, {});
+    const vehicleTypes = await asAdmin.query(api.vehicleTypes.list, {});
+    const car = vehicleTypes.find((vehicleType) => vehicleType.slug === "car");
+    const motorcycle = vehicleTypes.find(
+      (vehicleType) => vehicleType.slug === "motorcycle",
+    );
+    expect(car).toBeDefined();
+    expect(motorcycle).toBeDefined();
+
+    await asAdmin.mutation(api.services.create, {
+      name: "Level 1 - Basic Reset",
+      description: "A clean reset for daily drivers",
+      duration: 60,
+      showOnLandingPage: true,
+      vehiclePrices: [
+        {
+          vehicleTypeId: car!._id,
+          price: 90,
+          duration: 60,
+          isAvailable: true,
+        },
+      ],
+    });
+
+    await asAdmin.mutation(api.services.create, {
+      name: "Motorcycle full detail",
+      description: "Motorcycle-specific detail",
+      duration: 150,
+      showOnLandingPage: true,
+      vehiclePrices: [
+        {
+          vehicleTypeId: motorcycle!._id,
+          price: 200,
+          duration: 150,
+          isAvailable: true,
+        },
+      ],
+    });
+
+    await asAdmin.mutation(api.services.create, {
+      name: "Admin-only package",
+      description: "Available for booking but hidden from landing pricing",
+      duration: 90,
+      showOnLandingPage: false,
+      vehiclePrices: [
+        {
+          vehicleTypeId: car!._id,
+          price: 125,
+          duration: 90,
+          isAvailable: true,
+        },
+      ],
+    });
+
+    await t.finishInProgressScheduledFunctions();
+
+    const groups = await t.query(api.services.listLandingPagePricing, {});
+    const carGroup = groups.find((group) => group.vehicleType.slug === "car");
+    const motorcycleGroup = groups.find(
+      (group) => group.vehicleType.slug === "motorcycle",
+    );
+
+    expect(carGroup?.services.map((service) => service.name)).toEqual([
+      "Level 1 - Basic Reset",
+    ]);
+    expect(motorcycleGroup?.services.map((service) => service.name)).toEqual([
+      "Motorcycle full detail",
+    ]);
+    expect(
+      groups.flatMap((group) => group.services.map((service) => service.name)),
+    ).not.toContain("Admin-only package");
+  });
+
   test("updates vehicle pricing rows and compatibility buckets", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/services.ts
+++ b/convex/services.ts
@@ -23,6 +23,23 @@ const SERVICE_TYPE_LABELS = {
   subscription: "Subscription Plans",
 } as const;
 
+const LANDING_PAGE_SERVICE_LIMIT = 5;
+
+type LandingPageService = {
+  _id: Id<"services">;
+  name: string;
+  description: string;
+  icon?: string;
+  features?: string[];
+  price: number;
+  duration: number;
+};
+
+type LandingPageVehicleGroup = {
+  vehicleType: Doc<"vehicleTypes">;
+  services: LandingPageService[];
+};
+
 function assertHasPositivePrice(args: {
   basePriceSmall?: number;
   basePriceMedium?: number;
@@ -582,6 +599,63 @@ export const list = query({
   },
 });
 
+export const listLandingPagePricing = query({
+  args: {},
+  handler: async (ctx) => {
+    const services = await ctx.db.query("services").collect();
+    const landingServices = services.filter((service) => {
+      const serviceType = normalizeServiceType(service.serviceType);
+      return (
+        service.isActive &&
+        service.showOnLandingPage !== false &&
+        serviceType === "standard"
+      );
+    });
+
+    const vehicleTypeMap = new Map<string, LandingPageVehicleGroup>();
+
+    for (const service of landingServices) {
+      const vehiclePrices = await getServiceVehiclePricesForPresentation(ctx, service);
+      for (const price of vehiclePrices) {
+        if (!price.isAvailable || price.price <= 0 || !price.vehicleType?.isActive) {
+          continue;
+        }
+
+        const vehicleTypeId = String(price.vehicleTypeId);
+        const existing: LandingPageVehicleGroup = vehicleTypeMap.get(vehicleTypeId) ?? {
+          vehicleType: price.vehicleType,
+          services: [],
+        };
+
+        existing.services.push({
+          _id: service._id,
+          name: service.name,
+          description: service.description,
+          icon: service.icon,
+          features: service.features,
+          price: price.price,
+          duration: price.duration || service.duration,
+        });
+        vehicleTypeMap.set(vehicleTypeId, existing);
+      }
+    }
+
+    return Array.from(vehicleTypeMap.values())
+      .map((group) => ({
+        vehicleType: group.vehicleType,
+        services: group.services
+          .sort((a, b) => a.price - b.price || a.name.localeCompare(b.name))
+          .slice(0, LANDING_PAGE_SERVICE_LIMIT),
+      }))
+      .filter((group) => group.services.length > 0)
+      .sort(
+        (a, b) =>
+          a.vehicleType.displayOrder - b.vehicleType.displayOrder ||
+          a.vehicleType.name.localeCompare(b.vehicleType.name),
+      );
+  },
+});
+
 // Create a new service or subscription
 export const create = mutation({
   args: {
@@ -603,6 +677,7 @@ export const create = mutation({
     includedServiceIds: v.optional(v.array(v.id("services"))),
     features: v.optional(v.array(v.string())),
     icon: v.optional(v.string()),
+    showOnLandingPage: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
@@ -628,6 +703,7 @@ export const create = mutation({
       features: args.features,
       icon: args.icon,
       isActive: true,
+      showOnLandingPage: args.showOnLandingPage ?? true,
     });
 
     const rows = await replaceServiceVehiclePrices(
@@ -689,6 +765,7 @@ export const update = mutation({
     features: v.optional(v.array(v.string())),
     icon: v.optional(v.string()),
     isActive: v.boolean(),
+    showOnLandingPage: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
@@ -735,6 +812,8 @@ export const update = mutation({
       features: updates.features,
       icon: updates.icon,
       isActive: updates.isActive,
+      showOnLandingPage:
+        updates.showOnLandingPage ?? existingService.showOnLandingPage ?? true,
       basePrice: rows
         ? legacyPrices.basePriceMedium ??
           legacyPrices.basePriceSmall ??


### PR DESCRIPTION
## Summary\n\n- Adds an admin-controlled landing page pricing flag for service products.\n- Adds a public landing pricing query that groups curated services by exact vehicle type availability and limits each tab to a clean set of cards.\n- Updates the public pricing UI from legacy small/medium/large tabs to dynamic vehicle type tabs such as Car, Truck, SUV, Van, and Motorcycle.\n\n## Implementation Notes\n\n- Existing products default to showing on the landing page unless an admin turns the new flag off.\n- Landing pricing only includes active standard services with an available positive price for the selected vehicle type, preventing motorcycle-only products from showing under other vehicle tabs.\n- The admin services list now shows whether a product is bookable and whether it appears on the landing page.\n\n## Testing Notes\n\n- pnpm exec convex codegen\n- pnpm test:once convex/services.test.ts\n- pnpm lint\n- pnpm exec tsc --noEmit\n- pnpm test:once\n- pnpm build\n- curl smoke test against http://localhost:3000\n\nCloses #63