### PR TITLE
fix: apply travel fee time buffers and appointment photo visibility

### DIFF
--- a/components/admin/appointments-client.tsx
+++ b/components/admin/appointments-client.tsx
@@ -20,6 +20,7 @@ import {
   AlertCircle,
   MoreHorizontal,
   ArrowUpDown,
+  Images,
 } from "lucide-react";
 import {
   Dialog,
@@ -52,6 +53,7 @@ type AppointmentRecord = {
   user: { name?: string; email?: string } | null;
   services: Array<{ _id: Id<"services">; name: string }>;
   vehicles: Array<{ _id: Id<"vehicles">; year: number; make: string; model: string; color?: string }>;
+  beforePhotos?: Array<{ key: string; fileName: string }>;
   tripLogStatus: "required" | "draft" | "completed" | null;
   tripLogId?: Id<"tripLogs">;
   tripLogRequiredReason?: "completed_without_log";
@@ -248,10 +250,17 @@ export default function AppointmentsClient({}: Props) {
       },
       cell: ({ row }) => {
         const user = row.original.user;
+        const photoCount = row.original.beforePhotos?.length ?? 0;
         return (
-          <div className="flex flex-col">
+          <div className="flex flex-col gap-1">
             <span className="font-medium">{user?.name || "Unknown"}</span>
             <span className="text-xs text-muted-foreground">{user?.email}</span>
+            {photoCount > 0 && (
+              <Badge variant="secondary" className="w-fit gap-1 text-[10px]">
+                <Images className="h-3 w-3" />
+                {photoCount} photo{photoCount === 1 ? "" : "s"}
+              </Badge>
+            )}
           </div>
         );
       },

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -19,7 +19,10 @@ import {
   normalizeUserNotificationPreferences,
 } from "./lib/notificationSettings";
 import { r2 } from "./r2";
-import { calculateTravelFeeForMiles } from "./lib/travelFees";
+import {
+  calculateTravelBufferMinutesForMiles,
+  calculateTravelFeeForMiles,
+} from "./lib/travelFees";
 import { isArkansasState } from "./lib/address";
 import {
   getEffectivePetFeePrice,
@@ -440,6 +443,10 @@ async function buildDraftPricing(args: {
     args.travelDistanceMiles !== undefined
       ? calculateTravelFeeForMiles(args.travelDistanceMiles)
       : 0;
+  const travelBufferMinutes =
+    args.travelDistanceMiles !== undefined
+      ? calculateTravelBufferMinutesForMiles(args.travelDistanceMiles)
+      : 0;
   const travelFeeItems =
     travelFee > 0 && args.travelDistanceMiles !== undefined
       ? [
@@ -459,6 +466,7 @@ async function buildDraftPricing(args: {
     serviceDurations: [duration],
     petFeeVehicleCount: activePetFeeSizes.length,
     petFeeTimeMinutes: petFeeSettings.timeAddMinutes,
+    travelBufferMinutes,
   });
   const depositSettings = await args.ctx.runQuery(
     internal.depositSettings.getInternal,
@@ -855,6 +863,10 @@ export const getSchedulingDurationInternal = internalQuery({
       serviceDurations,
       petFeeVehicleCount,
       petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
+      travelBufferMinutes:
+        draft.travelDistanceMiles !== undefined
+          ? calculateTravelBufferMinutesForMiles(draft.travelDistanceMiles)
+          : 0,
     });
   },
 });

--- a/convex/lib/booking.ts
+++ b/convex/lib/booking.ts
@@ -6,6 +6,7 @@ export function calculateSchedulingDuration(args: {
   serviceDurations: number[];
   petFeeVehicleCount?: number;
   petFeeTimeMinutes?: number;
+  travelBufferMinutes?: number;
 }): number {
   const serviceDuration = args.serviceDurations.reduce(
     (sum, duration) => sum + Math.max(0, duration || 0),
@@ -14,7 +15,8 @@ export function calculateSchedulingDuration(args: {
   const petFeeDuration =
     Math.max(0, args.petFeeVehicleCount ?? 0) *
     Math.max(0, args.petFeeTimeMinutes ?? DEFAULT_PET_FEE_TIME_MINUTES);
-  const computedDuration = serviceDuration + petFeeDuration;
+  const travelDuration = Math.max(0, args.travelBufferMinutes ?? 0);
+  const computedDuration = serviceDuration + petFeeDuration + travelDuration;
 
   return Math.max(computedDuration, BOOKING_BLOCK_MINUTES);
 }

--- a/convex/lib/travelFees.ts
+++ b/convex/lib/travelFees.ts
@@ -21,6 +21,12 @@ export function calculateTravelFeeForMiles(distanceMiles: number) {
   if (distanceMiles < 25) return 0;
   if (distanceMiles <= 35) return 30;
   if (distanceMiles <= 50) return 50;
-  const fee = distanceMiles * 0.75;
+  const fee = 50 + (distanceMiles - 50) * 0.75;
   return Math.round(fee * 100) / 100;
+}
+
+export function calculateTravelBufferMinutesForMiles(distanceMiles: number) {
+  if (distanceMiles < 25) return 0;
+  if (distanceMiles <= 35) return 30;
+  return 60;
 }

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -448,7 +448,7 @@ describe("payments", () => {
         description: "Service with travel fee",
         basePrice: 120,
         basePriceMedium: 120,
-        duration: 60,
+        duration: 120,
         serviceType: "standard",
         isActive: true,
       });
@@ -484,17 +484,18 @@ describe("payments", () => {
 
     expect(booking.travelDistanceMiles).toBeGreaterThan(68);
     expect(booking.travelDistanceMiles).toBeLessThan(70);
-    expect(booking.travelFee).toBe(51.83);
-    expect(draft?.totalPrice).toBeCloseTo(171.83, 2);
-    expect(draft?.travelFee).toBe(51.83);
+    expect(booking.travelFee).toBe(64.32);
+    expect(draft?.totalPrice).toBeCloseTo(184.32, 2);
+    expect(draft?.duration).toBe(180);
+    expect(draft?.travelFee).toBe(64.32);
     expect(draft?.travelDistanceMiles).toBeGreaterThan(68);
     expect(draft?.travelDistanceMiles).toBeLessThan(70);
     expect(draft?.priceSnapshot).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemType: "travel_fee",
-          unitPrice: 51.83,
-          totalPrice: 51.83,
+          unitPrice: 64.32,
+          totalPrice: 64.32,
         }),
       ]),
     );

--- a/convex/travelFees.test.ts
+++ b/convex/travelFees.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api";
 import {
   calculateHaversineDistance,
+  calculateTravelBufferMinutesForMiles,
   calculateTravelFeeForMiles,
 } from "./lib/travelFees";
 import schema from "./schema";
@@ -19,8 +20,17 @@ describe("travelFees", () => {
     expect(calculateTravelFeeForMiles(35)).toBe(30);
     expect(calculateTravelFeeForMiles(35.1)).toBe(50);
     expect(calculateTravelFeeForMiles(50)).toBe(50);
-    expect(calculateTravelFeeForMiles(50.1)).toBe(37.58);
-    expect(calculateTravelFeeForMiles(100)).toBe(75);
+    expect(calculateTravelFeeForMiles(50.1)).toBe(50.08);
+    expect(calculateTravelFeeForMiles(100)).toBe(87.5);
+  });
+
+  test("uses travel buffers for appointment blocking", () => {
+    expect(calculateTravelBufferMinutesForMiles(24.9)).toBe(0);
+    expect(calculateTravelBufferMinutesForMiles(25)).toBe(30);
+    expect(calculateTravelBufferMinutesForMiles(35)).toBe(30);
+    expect(calculateTravelBufferMinutesForMiles(35.1)).toBe(60);
+    expect(calculateTravelBufferMinutesForMiles(50)).toBe(60);
+    expect(calculateTravelBufferMinutesForMiles(50.1)).toBe(60);
   });
 
   test("calculates haversine distance in miles", () => {


### PR DESCRIPTION
## Summary

- Update Arkansas travel fee pricing to use the requested 25-35, 36-50, and over-50 mile tiers.
- Add travel buffer minutes to booking draft scheduling duration so longer-distance appointments block commute time.
- Surface uploaded appointment photos in the admin appointment list when attachments are present.

## Implementation Notes

- Travel fee tiers are now: $0 under 25 miles, $30 from 25-35 miles, $50 from 36-50 miles, and $50 + $0.75 per mile over 50 miles.
- Scheduling duration now adds 30 minutes for 25-35 miles and 60 minutes beyond 35 miles, including checkout availability rechecks.
- Existing appointment detail photo rendering remains in place; the list now shows a photo count badge for appointments with before photos.

## Testing Notes

- pnpm test:once
- pnpm build
- pnpm lint
- pnpm check (script not defined in package.json)
- pnpm typecheck (script not defined in package.json; Next build ran TypeScript)

Closes #67