### PR TITLE
fix: make travel fee rates configurable

### DIFF
--- a/components/admin/services-client.tsx
+++ b/components/admin/services-client.tsx
@@ -100,6 +100,20 @@ export default function ServicesClient() {
     timeAddMinutes: DEFAULT_PET_FEE_TIME_MINUTES,
     isActive: true,
   });
+  const travelFeeSettings = useQuery(api.travelFeeSettings.get);
+  const updateTravelFeeSettings = useMutation(api.travelFeeSettings.upsert);
+  const [isEditingTravelFee, setIsEditingTravelFee] = useState(false);
+  const [travelFeeValues, setTravelFeeValues] = useState({
+    freeRadiusMiles: 25,
+    midRangeMaxMiles: 35,
+    longRangeMaxMiles: 50,
+    midRangeFee: 30,
+    longRangeFee: 50,
+    perMileRateAfterLongRange: 2,
+    midRangeBufferMinutes: 30,
+    longRangeBufferMinutes: 60,
+    isActive: true,
+  });
 
   useEffect(() => {
     if (depositSettings) {
@@ -116,6 +130,12 @@ export default function ServicesClient() {
       });
     }
   }, [petFeeSettings]);
+
+  useEffect(() => {
+    if (travelFeeSettings) {
+      setTravelFeeValues(travelFeeSettings);
+    }
+  }, [travelFeeSettings]);
 
   if (servicesQuery === undefined) {
     return (
@@ -206,6 +226,18 @@ export default function ServicesClient() {
     const settings = petFeeSettings ?? petFeePrices;
     if (!settings.isActive) return "Pet fee off";
     return `Pet fee: S $${settings.basePriceSmall.toFixed(0)} • M $${settings.basePriceMedium.toFixed(0)} • L $${settings.basePriceLarge.toFixed(0)} • +${settings.timeAddMinutes ?? DEFAULT_PET_FEE_TIME_MINUTES} min`;
+  };
+
+  const formatTravelFeePricing = () => {
+    const settings = travelFeeSettings ?? travelFeeValues;
+    if (!settings.isActive) return "Travel fees off";
+    return `Travel: <${
+      settings.freeRadiusMiles
+    } mi free • $${settings.midRangeFee.toFixed(0)} to ${
+      settings.midRangeMaxMiles
+    } mi • $${settings.longRangeFee.toFixed(0)} to ${
+      settings.longRangeMaxMiles
+    } mi • $${settings.perMileRateAfterLongRange.toFixed(2)}/mi after`;
   };
 
   const popularityBadgeClass = (popularity?: string) => {
@@ -540,6 +572,81 @@ export default function ServicesClient() {
                 {formatPetFeePricing()}
               </span>
               <Button size="sm" variant="ghost" onClick={() => setIsEditingPetFee(true)}>
+                <Edit className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+          {isEditingTravelFee ? (
+            <div className="flex flex-wrap items-end gap-2 rounded-md border p-2">
+              <div className="flex items-center gap-2 pb-2">
+                <Switch
+                  checked={travelFeeValues.isActive}
+                  onCheckedChange={(checked) =>
+                    setTravelFeeValues((current) => ({ ...current, isActive: checked }))
+                  }
+                />
+                <span className="text-sm text-muted-foreground">Travel fee</span>
+              </div>
+              {[
+                ["freeRadiusMiles", "Free under mi", "1"],
+                ["midRangeMaxMiles", "Mid max mi", "1"],
+                ["longRangeMaxMiles", "Long max mi", "1"],
+                ["midRangeFee", "Mid fee", "0.01"],
+                ["longRangeFee", "Long fee", "0.01"],
+                ["perMileRateAfterLongRange", "After long $/mi", "0.01"],
+                ["midRangeBufferMinutes", "Mid min", "5"],
+                ["longRangeBufferMinutes", "Long min", "5"],
+              ].map(([key, label, step]) => (
+                <div key={key} className="space-y-1">
+                  <Label className="text-xs">{label}</Label>
+                  <Input
+                    type="number"
+                    step={step}
+                    value={travelFeeValues[key as keyof typeof travelFeeValues] as number}
+                    onChange={(event) =>
+                      setTravelFeeValues((current) => ({
+                        ...current,
+                        [key]: parseFloat(event.target.value) || 0,
+                      }))
+                    }
+                    className="w-24"
+                  />
+                </div>
+              ))}
+              <Button
+                size="sm"
+                onClick={async () => {
+                  try {
+                    await updateTravelFeeSettings(travelFeeValues);
+                    setIsEditingTravelFee(false);
+                    toast.success("Travel fee settings updated");
+                    router.refresh();
+                  } catch {
+                    toast.error("Failed to update travel fee settings");
+                  }
+                }}
+              >
+                <Save className="h-4 w-4" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsEditingTravelFee(false);
+                  if (travelFeeSettings) {
+                    setTravelFeeValues(travelFeeSettings);
+                  }
+                }}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                {formatTravelFeePricing()}
+              </span>
+              <Button size="sm" variant="ghost" onClick={() => setIsEditingTravelFee(true)}>
                 <Edit className="h-4 w-4" />
               </Button>
             </div>

--- a/components/booking/booking-flow.tsx
+++ b/components/booking/booking-flow.tsx
@@ -173,6 +173,7 @@ export default function BookingFlow() {
   const [travelQuote, setTravelQuote] = useState<{
     distanceMiles: number;
     fee: number;
+    bufferMinutes: number;
   } | null>(null);
   const { user, isLoaded, isSignedIn } = useUser();
   const [expandedVehicleIndex, setExpandedVehicleIndex] = useState<number>(0);
@@ -449,6 +450,7 @@ export default function BookingFlow() {
       serviceDurations,
       petFeeVehicleCount,
       petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
+      travelBufferMinutes: travelQuote?.bufferMinutes,
     });
   }, [
     petFeeSettings?.isActive,
@@ -457,6 +459,7 @@ export default function BookingFlow() {
     step3Data?.vehicles,
     step4Data?.serviceIds,
     step4Data?.vehicleServices,
+    travelQuote?.bufferMinutes,
   ]);
 
   const step2Form = useForm<Step2Data>({
@@ -811,6 +814,7 @@ export default function BookingFlow() {
             serviceDurations,
             petFeeVehicleCount,
             petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
+            travelBufferMinutes: travelQuote?.bufferMinutes,
           });
           const scheduledDateValue = step1Data?.scheduledDate;
           const scheduledDate =
@@ -930,7 +934,11 @@ export default function BookingFlow() {
         paymentOption,
       });
       setResumeToken(nextResumeToken);
-      setTravelQuote({ distanceMiles: travelDistanceMiles, fee: travelFee });
+      setTravelQuote({
+        distanceMiles: travelDistanceMiles,
+        fee: travelFee,
+        bufferMinutes: travelQuote?.bufferMinutes ?? 0,
+      });
 
       const { url } = await createBookingCheckout({
         draftId,

--- a/components/forms/dashboard/dashboard-appointment-form.tsx
+++ b/components/forms/dashboard/dashboard-appointment-form.tsx
@@ -108,6 +108,7 @@ export function DashboardAppointmentForm({
   const [travelQuote, setTravelQuote] = useState<{
     distanceMiles: number;
     fee: number;
+    bufferMinutes: number;
   } | null>(null);
 
   // Queries
@@ -350,12 +351,14 @@ export function DashboardAppointmentForm({
         petFeeVehicleCount:
           hasPetFee && petFeeSettings?.isActive !== false ? 1 : 0,
         petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
+        travelBufferMinutes: travelQuote?.bufferMinutes,
       }),
     [
       hasPetFee,
       petFeeSettings?.isActive,
       petFeeSettings?.timeAddMinutes,
       selectedServicesData,
+      travelQuote?.bufferMinutes,
       vehiclePricingContext,
     ],
   );

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -44,6 +44,7 @@ import type * as subscriptions from "../subscriptions.js";
 import type * as testEmails from "../testEmails.js";
 import type * as testFlows from "../testFlows.js";
 import type * as testUtils_bookingSetup from "../testUtils/bookingSetup.js";
+import type * as travelFeeSettings from "../travelFeeSettings.js";
 import type * as travelFees from "../travelFees.js";
 import type * as tripLogs from "../tripLogs.js";
 import type * as users from "../users.js";
@@ -94,6 +95,7 @@ declare const fullApi: ApiFromModules<{
   testEmails: typeof testEmails;
   testFlows: typeof testFlows;
   "testUtils/bookingSetup": typeof testUtils_bookingSetup;
+  travelFeeSettings: typeof travelFeeSettings;
   travelFees: typeof travelFees;
   tripLogs: typeof tripLogs;
   users: typeof users;

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -22,6 +22,7 @@ import { r2 } from "./r2";
 import {
   calculateTravelBufferMinutesForMiles,
   calculateTravelFeeForMiles,
+  type TravelFeeSettings,
 } from "./lib/travelFees";
 import { isArkansasState } from "./lib/address";
 import {
@@ -33,6 +34,28 @@ import { assertRateLimit, contactRateLimitKey } from "./rateLimiter";
 
 const HOLD_DURATION_MS = 15 * 60 * 1000;
 const ABANDONED_EMAIL_DELAY_MS = 60 * 60 * 1000;
+
+type DraftPriceItem = {
+  itemType: "service" | "pet_fee" | "travel_fee";
+  serviceId?: Id<"services">;
+  vehicleId?: Id<"vehicles">;
+  vehicleLabel?: string;
+  vehicleTypeId?: Id<"vehicleTypes">;
+  serviceName: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+};
+
+type DraftPricingResult = {
+  services: Doc<"services">[];
+  items: DraftPriceItem[];
+  totalPrice: number;
+  duration: number;
+  depositAmount: number;
+  remainingBalance: number;
+  travelFee: number;
+};
 
 const addressValidator = v.object({
   street: v.string(),
@@ -320,7 +343,7 @@ async function buildDraftPricing(args: {
   existingVehicleServices?: Array<{ vehicleId: Id<"vehicles">; serviceIds: Id<"services">[] }>;
   petFeeExistingVehicleIds: Id<"vehicles">[];
   travelDistanceMiles?: number;
-}) {
+}): Promise<DraftPricingResult> {
   // Collect all serviceIds across all vehicles
   const allServiceIdsSet = new Set<Id<"services">>();
   args.serviceIds.forEach((id) => allServiceIdsSet.add(id));
@@ -348,7 +371,7 @@ async function buildDraftPricing(args: {
     })),
   ];
 
-  const items = [];
+  const items: DraftPriceItem[] = [];
   let duration = 0;
   for (const { vehicle, vehicleId, vehicleLabel } of bookingVehicles) {
     let vehicleServiceIds = args.serviceIds;
@@ -425,6 +448,10 @@ async function buildDraftPricing(args: {
   ];
   const activePetFeeSizes: VehicleSize[] =
     petFeeSettings.isActive === false ? [] : petFeeSizes;
+  const travelFeeSettings: TravelFeeSettings = await args.ctx.runQuery(
+    internal.travelFeeSettings.getInternal,
+    {},
+  );
   const petFeeItems = (["small", "medium", "large"] as VehicleSize[])
     .map((size) => {
       const quantity = activePetFeeSizes.filter((petFeeSize) => petFeeSize === size).length;
@@ -439,15 +466,18 @@ async function buildDraftPricing(args: {
     })
     .filter((item) => item.quantity > 0 && item.totalPrice > 0);
 
-  const travelFee =
+  const travelFee: number =
     args.travelDistanceMiles !== undefined
-      ? calculateTravelFeeForMiles(args.travelDistanceMiles)
+      ? calculateTravelFeeForMiles(args.travelDistanceMiles, travelFeeSettings)
       : 0;
   const travelBufferMinutes =
     args.travelDistanceMiles !== undefined
-      ? calculateTravelBufferMinutesForMiles(args.travelDistanceMiles)
+      ? calculateTravelBufferMinutesForMiles(
+          args.travelDistanceMiles,
+          travelFeeSettings,
+        )
       : 0;
-  const travelFeeItems =
+  const travelFeeItems: DraftPriceItem[] =
     travelFee > 0 && args.travelDistanceMiles !== undefined
       ? [
           {
@@ -816,6 +846,7 @@ export const getSchedulingDurationInternal = internalQuery({
 
     const services = await getServicesForDraft(ctx, draft.serviceIds);
     const petFeeSettings = await ctx.db.query("petFeeSettings").first();
+    const travelFeeSettings = await ctx.db.query("travelFeeSettings").first();
     const petFeeExistingVehicleIdSet = new Set(draft.petFeeExistingVehicleIds ?? []);
     const existingVehicles = (
       await Promise.all(
@@ -865,7 +896,10 @@ export const getSchedulingDurationInternal = internalQuery({
       petFeeTimeMinutes: petFeeSettings?.timeAddMinutes,
       travelBufferMinutes:
         draft.travelDistanceMiles !== undefined
-          ? calculateTravelBufferMinutesForMiles(draft.travelDistanceMiles)
+          ? calculateTravelBufferMinutesForMiles(
+              draft.travelDistanceMiles,
+              travelFeeSettings ?? undefined,
+            )
           : 0,
     });
   },

--- a/convex/lib/travelFees.ts
+++ b/convex/lib/travelFees.ts
@@ -1,3 +1,94 @@
+import { v } from "convex/values";
+
+export const travelFeeSettingsValidator = v.object({
+  freeRadiusMiles: v.number(),
+  midRangeMaxMiles: v.number(),
+  longRangeMaxMiles: v.number(),
+  midRangeFee: v.number(),
+  longRangeFee: v.number(),
+  perMileRateAfterLongRange: v.number(),
+  midRangeBufferMinutes: v.number(),
+  longRangeBufferMinutes: v.number(),
+  isActive: v.boolean(),
+});
+
+export type TravelFeeSettings = {
+  freeRadiusMiles: number;
+  midRangeMaxMiles: number;
+  longRangeMaxMiles: number;
+  midRangeFee: number;
+  longRangeFee: number;
+  perMileRateAfterLongRange: number;
+  midRangeBufferMinutes: number;
+  longRangeBufferMinutes: number;
+  isActive: boolean;
+};
+
+export const defaultTravelFeeSettings: TravelFeeSettings = {
+  freeRadiusMiles: 25,
+  midRangeMaxMiles: 35,
+  longRangeMaxMiles: 50,
+  midRangeFee: 30,
+  longRangeFee: 50,
+  perMileRateAfterLongRange: 2,
+  midRangeBufferMinutes: 30,
+  longRangeBufferMinutes: 60,
+  isActive: true,
+};
+
+function cleanNumber(value: number | undefined, fallback: number) {
+  return Number.isFinite(value) ? Number(value) : fallback;
+}
+
+function cleanMoney(value: number | undefined, fallback: number) {
+  return Math.max(0, cleanNumber(value, fallback));
+}
+
+function cleanMinutes(value: number | undefined, fallback: number) {
+  return Math.max(0, Math.floor(cleanNumber(value, fallback)));
+}
+
+export function normalizeTravelFeeSettings(
+  settings: Partial<TravelFeeSettings>,
+): TravelFeeSettings {
+  const freeRadiusMiles = cleanNumber(
+    settings.freeRadiusMiles,
+    defaultTravelFeeSettings.freeRadiusMiles,
+  );
+  const midRangeMaxMiles = Math.max(
+    freeRadiusMiles,
+    cleanNumber(settings.midRangeMaxMiles, defaultTravelFeeSettings.midRangeMaxMiles),
+  );
+  const longRangeMaxMiles = Math.max(
+    midRangeMaxMiles,
+    cleanNumber(settings.longRangeMaxMiles, defaultTravelFeeSettings.longRangeMaxMiles),
+  );
+
+  return {
+    freeRadiusMiles,
+    midRangeMaxMiles,
+    longRangeMaxMiles,
+    midRangeFee: cleanMoney(settings.midRangeFee, defaultTravelFeeSettings.midRangeFee),
+    longRangeFee: cleanMoney(
+      settings.longRangeFee,
+      defaultTravelFeeSettings.longRangeFee,
+    ),
+    perMileRateAfterLongRange: cleanMoney(
+      settings.perMileRateAfterLongRange,
+      defaultTravelFeeSettings.perMileRateAfterLongRange,
+    ),
+    midRangeBufferMinutes: cleanMinutes(
+      settings.midRangeBufferMinutes,
+      defaultTravelFeeSettings.midRangeBufferMinutes,
+    ),
+    longRangeBufferMinutes: cleanMinutes(
+      settings.longRangeBufferMinutes,
+      defaultTravelFeeSettings.longRangeBufferMinutes,
+    ),
+    isActive: settings.isActive ?? defaultTravelFeeSettings.isActive,
+  };
+}
+
 export function calculateHaversineDistance(
   lat1: number,
   lon1: number,
@@ -17,16 +108,31 @@ export function calculateHaversineDistance(
   return R * c;
 }
 
-export function calculateTravelFeeForMiles(distanceMiles: number) {
-  if (distanceMiles < 25) return 0;
-  if (distanceMiles <= 35) return 30;
-  if (distanceMiles <= 50) return 50;
-  const fee = 50 + (distanceMiles - 50) * 0.75;
+export function calculateTravelFeeForMiles(
+  distanceMiles: number,
+  settingsInput: Partial<TravelFeeSettings> = defaultTravelFeeSettings,
+) {
+  const settings = normalizeTravelFeeSettings(settingsInput);
+  if (!settings.isActive) return 0;
+  if (distanceMiles < settings.freeRadiusMiles) return 0;
+  if (distanceMiles <= settings.midRangeMaxMiles) return settings.midRangeFee;
+  if (distanceMiles <= settings.longRangeMaxMiles) return settings.longRangeFee;
+  const fee =
+    settings.longRangeFee +
+    (distanceMiles - settings.longRangeMaxMiles) *
+      settings.perMileRateAfterLongRange;
   return Math.round(fee * 100) / 100;
 }
 
-export function calculateTravelBufferMinutesForMiles(distanceMiles: number) {
-  if (distanceMiles < 25) return 0;
-  if (distanceMiles <= 35) return 30;
-  return 60;
+export function calculateTravelBufferMinutesForMiles(
+  distanceMiles: number,
+  settingsInput: Partial<TravelFeeSettings> = defaultTravelFeeSettings,
+) {
+  const settings = normalizeTravelFeeSettings(settingsInput);
+  if (!settings.isActive) return 0;
+  if (distanceMiles < settings.freeRadiusMiles) return 0;
+  if (distanceMiles <= settings.midRangeMaxMiles) {
+    return settings.midRangeBufferMinutes;
+  }
+  return settings.longRangeBufferMinutes;
 }

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -484,18 +484,18 @@ describe("payments", () => {
 
     expect(booking.travelDistanceMiles).toBeGreaterThan(68);
     expect(booking.travelDistanceMiles).toBeLessThan(70);
-    expect(booking.travelFee).toBe(64.32);
-    expect(draft?.totalPrice).toBeCloseTo(184.32, 2);
+    expect(booking.travelFee).toBe(88.2);
+    expect(draft?.totalPrice).toBeCloseTo(208.2, 2);
     expect(draft?.duration).toBe(180);
-    expect(draft?.travelFee).toBe(64.32);
+    expect(draft?.travelFee).toBe(88.2);
     expect(draft?.travelDistanceMiles).toBeGreaterThan(68);
     expect(draft?.travelDistanceMiles).toBeLessThan(70);
     expect(draft?.priceSnapshot).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemType: "travel_fee",
-          unitPrice: 64.32,
-          totalPrice: 64.32,
+          unitPrice: 88.2,
+          totalPrice: 88.2,
         }),
       ]),
     );

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -148,6 +148,19 @@ const schema = defineSchema({
     isActive: v.boolean(),
   }),
 
+  // Travel Fee Settings
+  travelFeeSettings: defineTable({
+    freeRadiusMiles: v.number(),
+    midRangeMaxMiles: v.number(),
+    longRangeMaxMiles: v.number(),
+    midRangeFee: v.number(),
+    longRangeFee: v.number(),
+    perMileRateAfterLongRange: v.number(),
+    midRangeBufferMinutes: v.number(),
+    longRangeBufferMinutes: v.number(),
+    isActive: v.boolean(),
+  }),
+
   // Services and Subscriptions
   services: defineTable({
     name: v.string(),

--- a/convex/travelFeeSettings.ts
+++ b/convex/travelFeeSettings.ts
@@ -1,0 +1,54 @@
+import { internalQuery, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireAdmin } from "./auth";
+import {
+  defaultTravelFeeSettings,
+  normalizeTravelFeeSettings,
+  travelFeeSettingsValidator,
+} from "./lib/travelFees";
+
+export const get = query({
+  args: {},
+  returns: travelFeeSettingsValidator,
+  handler: async (ctx) => {
+    const settings = await ctx.db.query("travelFeeSettings").first();
+    return normalizeTravelFeeSettings(settings ?? defaultTravelFeeSettings);
+  },
+});
+
+export const getInternal = internalQuery({
+  args: {},
+  returns: travelFeeSettingsValidator,
+  handler: async (ctx) => {
+    const settings = await ctx.db.query("travelFeeSettings").first();
+    return normalizeTravelFeeSettings(settings ?? defaultTravelFeeSettings);
+  },
+});
+
+export const upsert = mutation({
+  args: {
+    freeRadiusMiles: v.number(),
+    midRangeMaxMiles: v.number(),
+    longRangeMaxMiles: v.number(),
+    midRangeFee: v.number(),
+    longRangeFee: v.number(),
+    perMileRateAfterLongRange: v.number(),
+    midRangeBufferMinutes: v.number(),
+    longRangeBufferMinutes: v.number(),
+    isActive: v.boolean(),
+  },
+  returns: v.id("travelFeeSettings"),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const existing = await ctx.db.query("travelFeeSettings").first();
+    const settings = normalizeTravelFeeSettings(args);
+
+    if (existing) {
+      await ctx.db.patch(existing._id, settings);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("travelFeeSettings", settings);
+  },
+});

--- a/convex/travelFees.test.ts
+++ b/convex/travelFees.test.ts
@@ -20,8 +20,40 @@ describe("travelFees", () => {
     expect(calculateTravelFeeForMiles(35)).toBe(30);
     expect(calculateTravelFeeForMiles(35.1)).toBe(50);
     expect(calculateTravelFeeForMiles(50)).toBe(50);
-    expect(calculateTravelFeeForMiles(50.1)).toBe(50.08);
-    expect(calculateTravelFeeForMiles(100)).toBe(87.5);
+    expect(calculateTravelFeeForMiles(50.1)).toBe(50.2);
+    expect(calculateTravelFeeForMiles(100)).toBe(150);
+  });
+
+  test("uses configurable travel fee settings", async () => {
+    const t = convexTest(schema, modules);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-travel-settings@example.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-travel-settings@example.com",
+    });
+
+    await asAdmin.mutation(api.travelFeeSettings.upsert, {
+      freeRadiusMiles: 20,
+      midRangeMaxMiles: 30,
+      longRangeMaxMiles: 40,
+      midRangeFee: 25,
+      longRangeFee: 45,
+      perMileRateAfterLongRange: 3,
+      midRangeBufferMinutes: 20,
+      longRangeBufferMinutes: 75,
+      isActive: true,
+    });
+
+    const settings = await t.query(api.travelFeeSettings.get, {});
+    expect(calculateTravelFeeForMiles(45, settings)).toBe(60);
+    expect(calculateTravelBufferMinutesForMiles(25, settings)).toBe(20);
+    expect(calculateTravelBufferMinutesForMiles(45, settings)).toBe(75);
   });
 
   test("uses travel buffers for appointment blocking", () => {
@@ -93,6 +125,6 @@ describe("travelFees", () => {
     });
 
     process.env.RADAR_SECRET_KEY = previousKey;
-    expect(result).toEqual({ distanceMiles: 0, fee: 0 });
+    expect(result).toEqual({ distanceMiles: 0, fee: 0, bufferMinutes: 0 });
   });
 });

--- a/convex/travelFees.ts
+++ b/convex/travelFees.ts
@@ -1,6 +1,12 @@
 import { ConvexError, v } from "convex/values";
 import { action } from "./_generated/server";
-import { calculateTravelFeeForMiles, calculateHaversineDistance } from "./lib/travelFees";
+import { internal } from "./_generated/api";
+import {
+  calculateTravelBufferMinutesForMiles,
+  calculateTravelFeeForMiles,
+  calculateHaversineDistance,
+  type TravelFeeSettings,
+} from "./lib/travelFees";
 import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
 const ORIGIN_LAT = 34.752258;
@@ -54,6 +60,7 @@ export const calculate = action({
   returns: v.object({
     distanceMiles: v.number(),
     fee: v.number(),
+    bufferMinutes: v.number(),
   }),
   handler: async (ctx, args) => {
     const addressKey = normalizeRateLimitKey(
@@ -103,10 +110,15 @@ export const calculate = action({
     }
 
     const distanceMiles = roundMiles(calculateHaversineDistance(ORIGIN_LAT, ORIGIN_LNG, lat, lng));
+    const settings: TravelFeeSettings = await ctx.runQuery(
+      internal.travelFeeSettings.getInternal,
+      {},
+    );
 
     return {
       distanceMiles,
-      fee: calculateTravelFeeForMiles(distanceMiles),
+      fee: calculateTravelFeeForMiles(distanceMiles, settings),
+      bufferMinutes: calculateTravelBufferMinutesForMiles(distanceMiles, settings),
     };
   },
 });


### PR DESCRIPTION
## Summary

- Change the default over-50-mile travel fee to $50 plus $2.00 per mile after 50 miles.
- Add configurable travel fee tiers and travel scheduling buffers for admins.
- Carry travel buffer minutes through booking and dashboard scheduling calculations so time slots block service + pet hair + travel time.

## Implementation Notes

- Added a travelFeeSettings Convex table and public/admin API with defaults for free radius, mid/long tier fees, per-mile overage, and buffer minutes.
- Booking draft pricing, travel fee estimates, checkout totals, and scheduling duration now use the configured travel rules.
- Admin Services now exposes travel fee controls beside deposit and pet fee settings.
- Pet hair already used timeAddMinutes in scheduling; this keeps that behavior and makes the adjacent travel buffers adjustable.

## Testing Notes

- pnpm lint
- pnpm test:once
- pnpm build
- pnpm check (script not defined in package.json)
- pnpm typecheck (script not defined in package.json; Next build ran TypeScript)

Closes #69