### PR TITLE
feat: make travel fee origin address configurable

### DIFF
--- a/components/admin/services-client.tsx
+++ b/components/admin/services-client.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ColumnDef } from "@tanstack/react-table";
-import { useMutation, useQuery } from "convex/react";
+import { useAction, useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { Card, CardContent } from "@/components/ui/card";
@@ -101,9 +101,15 @@ export default function ServicesClient() {
     isActive: true,
   });
   const travelFeeSettings = useQuery(api.travelFeeSettings.get);
-  const updateTravelFeeSettings = useMutation(api.travelFeeSettings.upsert);
+  const updateTravelFeeSettings = useAction(api.travelFeeSettings.validateOriginAndUpsert);
   const [isEditingTravelFee, setIsEditingTravelFee] = useState(false);
   const [travelFeeValues, setTravelFeeValues] = useState({
+    originStreet: "220 N. Tyler St",
+    originCity: "Little Rock",
+    originState: "AR",
+    originZip: "72205",
+    originLatitude: 34.752258,
+    originLongitude: -92.329768,
     freeRadiusMiles: 25,
     midRangeMaxMiles: 35,
     longRangeMaxMiles: 50,
@@ -588,6 +594,26 @@ export default function ServicesClient() {
                 <span className="text-sm text-muted-foreground">Travel fee</span>
               </div>
               {[
+                ["originStreet", "Origin street"],
+                ["originCity", "Origin city"],
+                ["originState", "State"],
+                ["originZip", "ZIP"],
+              ].map(([key, label]) => (
+                <div key={key} className="space-y-1">
+                  <Label className="text-xs">{label}</Label>
+                  <Input
+                    value={travelFeeValues[key as keyof typeof travelFeeValues] as string}
+                    onChange={(event) =>
+                      setTravelFeeValues((current) => ({
+                        ...current,
+                        [key]: event.target.value,
+                      }))
+                    }
+                    className={key === "originStreet" ? "w-44" : "w-24"}
+                  />
+                </div>
+              ))}
+              {[
                 ["freeRadiusMiles", "Free under mi", "1"],
                 ["midRangeMaxMiles", "Mid max mi", "1"],
                 ["longRangeMaxMiles", "Long max mi", "1"],
@@ -617,7 +643,22 @@ export default function ServicesClient() {
                 size="sm"
                 onClick={async () => {
                   try {
-                    await updateTravelFeeSettings(travelFeeValues);
+                    await updateTravelFeeSettings({
+                      originStreet: travelFeeValues.originStreet,
+                      originCity: travelFeeValues.originCity,
+                      originState: travelFeeValues.originState,
+                      originZip: travelFeeValues.originZip,
+                      freeRadiusMiles: travelFeeValues.freeRadiusMiles,
+                      midRangeMaxMiles: travelFeeValues.midRangeMaxMiles,
+                      longRangeMaxMiles: travelFeeValues.longRangeMaxMiles,
+                      midRangeFee: travelFeeValues.midRangeFee,
+                      longRangeFee: travelFeeValues.longRangeFee,
+                      perMileRateAfterLongRange:
+                        travelFeeValues.perMileRateAfterLongRange,
+                      midRangeBufferMinutes: travelFeeValues.midRangeBufferMinutes,
+                      longRangeBufferMinutes: travelFeeValues.longRangeBufferMinutes,
+                      isActive: travelFeeValues.isActive,
+                    });
                     setIsEditingTravelFee(false);
                     toast.success("Travel fee settings updated");
                     router.refresh();

--- a/convex/lib/travelFees.ts
+++ b/convex/lib/travelFees.ts
@@ -1,6 +1,12 @@
 import { v } from "convex/values";
 
 export const travelFeeSettingsValidator = v.object({
+  originStreet: v.string(),
+  originCity: v.string(),
+  originState: v.string(),
+  originZip: v.string(),
+  originLatitude: v.number(),
+  originLongitude: v.number(),
   freeRadiusMiles: v.number(),
   midRangeMaxMiles: v.number(),
   longRangeMaxMiles: v.number(),
@@ -13,6 +19,12 @@ export const travelFeeSettingsValidator = v.object({
 });
 
 export type TravelFeeSettings = {
+  originStreet: string;
+  originCity: string;
+  originState: string;
+  originZip: string;
+  originLatitude: number;
+  originLongitude: number;
   freeRadiusMiles: number;
   midRangeMaxMiles: number;
   longRangeMaxMiles: number;
@@ -25,6 +37,12 @@ export type TravelFeeSettings = {
 };
 
 export const defaultTravelFeeSettings: TravelFeeSettings = {
+  originStreet: "220 N. Tyler St",
+  originCity: "Little Rock",
+  originState: "AR",
+  originZip: "72205",
+  originLatitude: 34.752258,
+  originLongitude: -92.329768,
   freeRadiusMiles: 25,
   midRangeMaxMiles: 35,
   longRangeMaxMiles: 50,
@@ -48,6 +66,11 @@ function cleanMinutes(value: number | undefined, fallback: number) {
   return Math.max(0, Math.floor(cleanNumber(value, fallback)));
 }
 
+function cleanString(value: string | undefined, fallback: string) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
 export function normalizeTravelFeeSettings(
   settings: Partial<TravelFeeSettings>,
 ): TravelFeeSettings {
@@ -65,6 +88,24 @@ export function normalizeTravelFeeSettings(
   );
 
   return {
+    originStreet: cleanString(
+      settings.originStreet,
+      defaultTravelFeeSettings.originStreet,
+    ),
+    originCity: cleanString(settings.originCity, defaultTravelFeeSettings.originCity),
+    originState: cleanString(
+      settings.originState,
+      defaultTravelFeeSettings.originState,
+    ),
+    originZip: cleanString(settings.originZip, defaultTravelFeeSettings.originZip),
+    originLatitude: cleanNumber(
+      settings.originLatitude,
+      defaultTravelFeeSettings.originLatitude,
+    ),
+    originLongitude: cleanNumber(
+      settings.originLongitude,
+      defaultTravelFeeSettings.originLongitude,
+    ),
     freeRadiusMiles,
     midRangeMaxMiles,
     longRangeMaxMiles,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -150,6 +150,12 @@ const schema = defineSchema({
 
   // Travel Fee Settings
   travelFeeSettings: defineTable({
+    originStreet: v.optional(v.string()),
+    originCity: v.optional(v.string()),
+    originState: v.optional(v.string()),
+    originZip: v.optional(v.string()),
+    originLatitude: v.optional(v.number()),
+    originLongitude: v.optional(v.number()),
     freeRadiusMiles: v.number(),
     midRangeMaxMiles: v.number(),
     longRangeMaxMiles: v.number(),

--- a/convex/travelFeeSettings.ts
+++ b/convex/travelFeeSettings.ts
@@ -1,11 +1,90 @@
-import { internalQuery, mutation, query } from "./_generated/server";
-import { v } from "convex/values";
+import {
+  action,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
+import { ConvexError, v } from "convex/values";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import { requireAdmin } from "./auth";
 import {
   defaultTravelFeeSettings,
   normalizeTravelFeeSettings,
+  type TravelFeeSettings,
   travelFeeSettingsValidator,
 } from "./lib/travelFees";
+
+const travelFeeSettingsArgs = {
+  originStreet: v.string(),
+  originCity: v.string(),
+  originState: v.string(),
+  originZip: v.string(),
+  freeRadiusMiles: v.number(),
+  midRangeMaxMiles: v.number(),
+  longRangeMaxMiles: v.number(),
+  midRangeFee: v.number(),
+  longRangeFee: v.number(),
+  perMileRateAfterLongRange: v.number(),
+  midRangeBufferMinutes: v.number(),
+  longRangeBufferMinutes: v.number(),
+  isActive: v.boolean(),
+};
+
+const travelFeeSettingsWithOriginArgs = {
+  ...travelFeeSettingsArgs,
+  originLatitude: v.number(),
+  originLongitude: v.number(),
+};
+
+async function geocodeOriginAddress(args: {
+  originStreet: string;
+  originCity: string;
+  originState: string;
+  originZip: string;
+}) {
+  const radarSecretKey = process.env.RADAR_SECRET_KEY;
+  if (!radarSecretKey) {
+    throw new ConvexError({
+      code: "MISSING_RADAR_SECRET_KEY",
+      message: "Travel origin validation is temporarily unavailable.",
+    });
+  }
+
+  const address = [
+    args.originStreet,
+    args.originCity,
+    args.originState,
+    args.originZip,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  const response = await fetch(
+    `https://api.radar.io/v1/geocode/forward?query=${encodeURIComponent(address)}&limit=1&country=US`,
+    { headers: { Authorization: radarSecretKey } },
+  );
+  if (!response.ok) {
+    throw new ConvexError({
+      code: "RADAR_GEOCODE_FAILED",
+      message: "We could not validate the travel origin address.",
+    });
+  }
+
+  const payload: any = await response.json();
+  const result = payload.addresses?.[0];
+  if (!result?.latitude || !result?.longitude) {
+    throw new ConvexError({
+      code: "RADAR_GEOCODE_EMPTY",
+      message: "We could not find coordinates for the travel origin address.",
+    });
+  }
+
+  return {
+    latitude: result.latitude as number,
+    longitude: result.longitude as number,
+  };
+}
 
 export const get = query({
   args: {},
@@ -26,17 +105,7 @@ export const getInternal = internalQuery({
 });
 
 export const upsert = mutation({
-  args: {
-    freeRadiusMiles: v.number(),
-    midRangeMaxMiles: v.number(),
-    longRangeMaxMiles: v.number(),
-    midRangeFee: v.number(),
-    longRangeFee: v.number(),
-    perMileRateAfterLongRange: v.number(),
-    midRangeBufferMinutes: v.number(),
-    longRangeBufferMinutes: v.number(),
-    isActive: v.boolean(),
-  },
+  args: travelFeeSettingsWithOriginArgs,
   returns: v.id("travelFeeSettings"),
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
@@ -50,5 +119,39 @@ export const upsert = mutation({
     }
 
     return await ctx.db.insert("travelFeeSettings", settings);
+  },
+});
+
+export const upsertInternal = internalMutation({
+  args: travelFeeSettingsWithOriginArgs,
+  returns: v.id("travelFeeSettings"),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.query("travelFeeSettings").first();
+    const settings = normalizeTravelFeeSettings(args);
+
+    if (existing) {
+      await ctx.db.patch(existing._id, settings);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("travelFeeSettings", settings);
+  },
+});
+
+export const validateOriginAndUpsert = action({
+  args: travelFeeSettingsArgs,
+  returns: v.id("travelFeeSettings"),
+  handler: async (ctx, args): Promise<Id<"travelFeeSettings">> => {
+    await requireAdmin(ctx);
+
+    const normalized = normalizeTravelFeeSettings(args);
+    const coords = await geocodeOriginAddress(normalized);
+    const settings: TravelFeeSettings = {
+      ...normalized,
+      originLatitude: coords.latitude,
+      originLongitude: coords.longitude,
+    };
+
+    return await ctx.runMutation(internal.travelFeeSettings.upsertInternal, settings);
   },
 });

--- a/convex/travelFees.test.ts
+++ b/convex/travelFees.test.ts
@@ -39,6 +39,12 @@ describe("travelFees", () => {
     });
 
     await asAdmin.mutation(api.travelFeeSettings.upsert, {
+      originStreet: "220 N. Tyler St",
+      originCity: "Little Rock",
+      originState: "AR",
+      originZip: "72205",
+      originLatitude: 34.752258,
+      originLongitude: -92.329768,
       freeRadiusMiles: 20,
       midRangeMaxMiles: 30,
       longRangeMaxMiles: 40,
@@ -54,6 +60,105 @@ describe("travelFees", () => {
     expect(calculateTravelFeeForMiles(45, settings)).toBe(60);
     expect(calculateTravelBufferMinutesForMiles(25, settings)).toBe(20);
     expect(calculateTravelBufferMinutesForMiles(45, settings)).toBe(75);
+  });
+
+  test("uses a custom configured origin for travel estimates", async () => {
+    const t = convexTest(schema, modules);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-origin-settings@example.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-origin-settings@example.com",
+    });
+
+    await asAdmin.mutation(api.travelFeeSettings.upsert, {
+      originStreet: "100 Origin Rd",
+      originCity: "Fayetteville",
+      originState: "AR",
+      originZip: "72701",
+      originLatitude: 36.06258,
+      originLongitude: -94.15743,
+      freeRadiusMiles: 25,
+      midRangeMaxMiles: 35,
+      longRangeMaxMiles: 50,
+      midRangeFee: 30,
+      longRangeFee: 50,
+      perMileRateAfterLongRange: 2,
+      midRangeBufferMinutes: 30,
+      longRangeBufferMinutes: 60,
+      isActive: true,
+    });
+
+    const result = await t.action(api.travelFees.calculate, {
+      address: {
+        street: "100 Destination Rd",
+        city: "Fayetteville",
+        state: "AR",
+        zip: "72701",
+        latitude: 36.16258,
+        longitude: -94.15743,
+      },
+    });
+
+    expect(result.distanceMiles).toBeGreaterThan(6);
+    expect(result.distanceMiles).toBeLessThan(8);
+    expect(result.fee).toBe(0);
+    expect(result.bufferMinutes).toBe(0);
+  });
+
+  test("geocodes and stores the admin origin address when settings are saved", async () => {
+    const previousKey = process.env.RADAR_SECRET_KEY;
+    process.env.RADAR_SECRET_KEY = "test_radar_key";
+    const t = convexTest(schema, modules);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-geocode-origin@example.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-geocode-origin@example.com",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        if (String(url).includes("/geocode/forward")) {
+          return Response.json({
+            addresses: [{ latitude: 36.06258, longitude: -94.15743 }],
+          });
+        }
+        return Response.json({}, { status: 404 });
+      }),
+    );
+
+    await asAdmin.action(api.travelFeeSettings.validateOriginAndUpsert, {
+      originStreet: "100 Origin Rd",
+      originCity: "Fayetteville",
+      originState: "AR",
+      originZip: "72701",
+      freeRadiusMiles: 25,
+      midRangeMaxMiles: 35,
+      longRangeMaxMiles: 50,
+      midRangeFee: 30,
+      longRangeFee: 50,
+      perMileRateAfterLongRange: 2,
+      midRangeBufferMinutes: 30,
+      longRangeBufferMinutes: 60,
+      isActive: true,
+    });
+
+    process.env.RADAR_SECRET_KEY = previousKey;
+    const settings = await t.query(api.travelFeeSettings.get, {});
+    expect(settings.originStreet).toBe("100 Origin Rd");
+    expect(settings.originLatitude).toBe(36.06258);
+    expect(settings.originLongitude).toBe(-94.15743);
   });
 
   test("uses travel buffers for appointment blocking", () => {

--- a/convex/travelFees.ts
+++ b/convex/travelFees.ts
@@ -9,9 +9,6 @@ import {
 } from "./lib/travelFees";
 import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
-const ORIGIN_LAT = 34.752258;
-const ORIGIN_LNG = -92.329768;
-
 const addressValidator = v.object({
   street: v.string(),
   city: v.string(),
@@ -109,10 +106,17 @@ export const calculate = action({
       lng = destCoords.longitude;
     }
 
-    const distanceMiles = roundMiles(calculateHaversineDistance(ORIGIN_LAT, ORIGIN_LNG, lat, lng));
     const settings: TravelFeeSettings = await ctx.runQuery(
       internal.travelFeeSettings.getInternal,
       {},
+    );
+    const distanceMiles = roundMiles(
+      calculateHaversineDistance(
+        settings.originLatitude,
+        settings.originLongitude,
+        lat,
+        lng,
+      ),
     );
 
     return {


### PR DESCRIPTION
## Summary

- Add configurable travel fee origin address fields to the existing travel fee settings.
- Geocode and store origin coordinates when admins save travel settings.
- Use the configured origin coordinates for booking travel fee estimates.

## Implementation Notes

- Defaults remain 220 N. Tyler St, Little Rock, AR 72205 with the existing coordinates.
- Existing settings records normalize missing origin fields to the default origin.
- Admin save uses Radar geocoding before persisting settings so checkout estimates can use stored coordinates.

## Testing Notes

- pnpm lint
- pnpm test:once convex/travelFees.test.ts convex/payments.test.ts
- pnpm test:once
- pnpm build

Closes #71