### PR TITLE
feat: support in-progress appointment adjustments

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -38,7 +38,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import type { Id } from "@/convex/_generated/dataModel";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { buildBusinessHoursForm } from "@/lib/business-hours";
 
 const businessSchema = z.object({
@@ -687,7 +687,7 @@ export default function SettingsPage() {
             <p className="text-sm text-muted-foreground">No upcoming time blocks</p>
           ) : (
             <div className="space-y-3">
-              {timeBlocks.map((block) => (
+              {timeBlocks.map((block: Doc<"timeBlocks">) => (
                 <div
                   key={block._id}
                   className="flex items-center justify-between gap-4 rounded-lg border p-3"

--- a/app/booking/resume/page.tsx
+++ b/app/booking/resume/page.tsx
@@ -29,6 +29,15 @@ function getVehicleTypeFromSize(size?: "small" | "medium" | "large") {
   }
 }
 
+type DraftVehicle = {
+  year: string;
+  make: string;
+  model: string;
+  size?: "small" | "medium" | "large";
+  color?: string;
+  licensePlate?: string;
+};
+
 export default function BookingResumePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -116,8 +125,9 @@ export default function BookingResumePage() {
         smsOptIn: draftContext.smsOptIn,
       },
       step3Data: {
-        vehicles: draftContext.vehicles.map((vehicle) => ({
+        vehicles: draftContext.vehicles.map((vehicle: DraftVehicle) => ({
           ...vehicle,
+          year: String(vehicle.year),
           type: getVehicleTypeFromSize(vehicle.size),
         })),
       },

--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -3,7 +3,7 @@
 import { useAction, useMutation, useQuery } from "convex/react";
 import { useRouter } from "next/navigation";
 import { api } from "@/convex/_generated/api";
-import type { Id } from "@/convex/_generated/dataModel";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
 import {
   Card,
   CardContent,
@@ -56,6 +56,18 @@ type Props = {
   appointmentId: Id<"appointments">;
 };
 
+type AppointmentVehicle = Doc<"vehicles"> & {
+  vehicleType?: Doc<"vehicleTypes"> | null;
+};
+
+type AppointmentService = Doc<"services"> & {
+  effectivePrice?: number;
+};
+
+type AppointmentBeforePhoto = NonNullable<Doc<"appointments">["beforePhotos"]>[number] & {
+  signedUrl?: string;
+};
+
 function getStatusColor(status: string) {
   switch (status) {
     case "confirmed":
@@ -80,6 +92,16 @@ function formatCurrency(amount: number) {
   }).format(amount);
 }
 
+function formatMinutes(minutes: number) {
+  const sign = minutes > 0 ? "+" : minutes < 0 ? "-" : "";
+  const absolute = Math.abs(minutes);
+  const hours = Math.floor(absolute / 60);
+  const remainder = absolute % 60;
+  if (hours === 0) return `${sign}${remainder} min`;
+  if (remainder === 0) return `${sign}${hours} hr`;
+  return `${sign}${hours} hr ${remainder} min`;
+}
+
 function getEffectivePrice(
   service: { basePrice?: number; basePriceSmall?: number; basePriceMedium?: number; basePriceLarge?: number },
   size: string,
@@ -101,6 +123,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
   const allServices = useQuery(api.services.list);
   const updateStatus = useMutation(api.appointments.updateStatus);
   const updateAppointment = useMutation(api.appointments.update);
+  const applyWorkAdjustment = useMutation(api.appointments.applyWorkAdjustment);
   const updateVehicle = useMutation(api.vehicles.updateVehicle);
   const updateBillingSettings = useMutation(api.invoices.updateBillingSettings);
   const reissueStripeInvoice = useAction(api.payments.reissueStripeInvoice);
@@ -130,6 +153,25 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
   const [editVehicleSizes, setEditVehicleSizes] = useState<Record<string, string>>({});
   const [editVehicleTypeIds, setEditVehicleTypeIds] = useState<Record<string, string>>({});
   const [editPetFeeVehicleIds, setEditPetFeeVehicleIds] = useState<Id<"vehicles">[]>([]);
+  const [adjustingWork, setAdjustingWork] = useState(false);
+  const [adjustVehicleIds, setAdjustVehicleIds] = useState<Id<"vehicles">[]>([]);
+  const [adjustServiceIds, setAdjustServiceIds] = useState<Id<"services">[]>([]);
+  const [adjustPetFeeVehicleIds, setAdjustPetFeeVehicleIds] = useState<Id<"vehicles">[]>([]);
+  const [adjustReason, setAdjustReason] = useState("");
+  const [adjustLoading, setAdjustLoading] = useState(false);
+  const adjustmentPreview = useQuery(
+    api.appointments.previewWorkAdjustment,
+    adjustingWork && adjustVehicleIds.length > 0 && adjustServiceIds.length > 0
+      ? {
+          appointmentId,
+          vehicleIds: adjustVehicleIds,
+          serviceIds: adjustServiceIds,
+          petFeeVehicleIds: adjustPetFeeVehicleIds,
+          reason: adjustReason || "Preview",
+        }
+      : "skip",
+  );
+  const adjustments = useQuery(api.appointments.listAdjustments, { appointmentId });
 
   useEffect(() => {
     if (!data?.invoice) return;
@@ -174,6 +216,14 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     );
   }
 
+  const typedVehicles = data.vehicles as AppointmentVehicle[];
+  const typedServices = data.services as AppointmentService[];
+  const customerVehicles = (customerVehiclesQuery ?? []) as AppointmentVehicle[];
+  const allServiceOptions = (allServices ?? []) as AppointmentService[];
+  const typedVehicleTypes = (vehicleTypes ?? []) as Doc<"vehicleTypes">[];
+  const typedAdjustments = (adjustments ?? []) as Doc<"appointmentAdjustments">[];
+  const beforePhotos = (data.beforePhotos ?? []) as AppointmentBeforePhoto[];
+
   const handleStatusUpdate = async (
     newStatus: "confirmed" | "in_progress" | "completed" | "cancelled",
   ) => {
@@ -200,16 +250,16 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     setEditNotes(data.notes || "");
     setEditServiceIds(data.serviceIds);
     setEditVehicleIds(
-      data.vehicles.length > 0
-        ? data.vehicles.map((vehicle) => vehicle._id)
-        : (customerVehiclesQuery?.length === 1
-            ? [customerVehiclesQuery[0]._id]
+      typedVehicles.length > 0
+        ? typedVehicles.map((vehicle) => vehicle._id)
+        : (customerVehicles.length === 1
+            ? [customerVehicles[0]._id]
             : []),
     );
     setEditPetFeeVehicleIds(data.petFeeVehicleIds ?? []);
     const sizes: Record<string, string> = {};
     const vehicleTypeIds: Record<string, string> = {};
-    for (const v of customerVehiclesQuery || data.vehicles) {
+    for (const v of customerVehicles.length > 0 ? customerVehicles : typedVehicles) {
       sizes[v._id] = v.size || "medium";
       vehicleTypeIds[v._id] = v.vehicleTypeId || "";
     }
@@ -222,6 +272,73 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     setEditing(false);
   };
 
+  const startWorkAdjustment = () => {
+    setAdjustVehicleIds(data.vehicleIds);
+    setAdjustServiceIds(data.serviceIds);
+    setAdjustPetFeeVehicleIds(data.petFeeVehicleIds ?? []);
+    setAdjustReason("");
+    setAdjustingWork(true);
+  };
+
+  const toggleAdjustVehicle = (vehicleId: Id<"vehicles">, checked: boolean) => {
+    setAdjustVehicleIds((prev) =>
+      checked ? [...new Set([...prev, vehicleId])] : prev.filter((id) => id !== vehicleId),
+    );
+    if (!checked) {
+      setAdjustPetFeeVehicleIds((prev) => prev.filter((id) => id !== vehicleId));
+    }
+  };
+
+  const toggleAdjustService = (serviceId: Id<"services">) => {
+    setAdjustServiceIds((prev) =>
+      prev.includes(serviceId)
+        ? prev.filter((id) => id !== serviceId)
+        : [...prev, serviceId],
+    );
+  };
+
+  const toggleAdjustPetFeeVehicle = (
+    vehicleId: Id<"vehicles">,
+    checked: boolean,
+  ) => {
+    setAdjustPetFeeVehicleIds((prev) =>
+      checked ? [...new Set([...prev, vehicleId])] : prev.filter((id) => id !== vehicleId),
+    );
+  };
+
+  const handleApplyWorkAdjustment = async () => {
+    if (adjustVehicleIds.length === 0) {
+      toast.error("Select at least one vehicle");
+      return;
+    }
+    if (adjustServiceIds.length === 0) {
+      toast.error("Select at least one service");
+      return;
+    }
+    if (adjustReason.trim().length < 3) {
+      toast.error("Add a short reason for the adjustment");
+      return;
+    }
+
+    setAdjustLoading(true);
+    try {
+      const result = await applyWorkAdjustment({
+        appointmentId,
+        vehicleIds: adjustVehicleIds,
+        serviceIds: adjustServiceIds,
+        petFeeVehicleIds: adjustPetFeeVehicleIds,
+        reason: adjustReason,
+      });
+      toast.success(`Work adjusted (${result.invoiceAction.replaceAll("_", " ")})`);
+      setAdjustingWork(false);
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to adjust work");
+    } finally {
+      setAdjustLoading(false);
+    }
+  };
+
   const handleSave = async () => {
     if (editVehicleIds.length === 0) {
       toast.error("Select at least one customer vehicle before saving");
@@ -231,7 +348,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     setLoading(true);
     try {
       // Update vehicle sizes first
-      for (const v of customerVehiclesQuery || data.vehicles) {
+      for (const v of customerVehicles.length > 0 ? customerVehicles : typedVehicles) {
         if (!editVehicleIds.includes(v._id)) {
           continue;
         }
@@ -338,11 +455,13 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     }
   };
 
-  const { user, services, vehicles, invoice, tripLog, location } = data;
-  const customerVehicles = customerVehiclesQuery ?? [];
+  const { user, invoice, tripLog, location } = data;
+  const services = typedServices;
+  const vehicles = typedVehicles;
+  const adjustmentVehicles = customerVehicles.length > 0 ? customerVehicles : vehicles;
   const beforePhotoGroups = Object.entries(
-    (data.beforePhotos ?? []).reduce<
-      Record<string, NonNullable<typeof data.beforePhotos>>
+    beforePhotos.reduce<
+      Record<string, AppointmentBeforePhoto[]>
     >((groups, photo) => {
       const label = photo.vehicleLabel || "Unassigned vehicle";
       groups[label] = [...(groups[label] ?? []), photo];
@@ -356,6 +475,8 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     (invoice.remainingBalance ?? 0) > 0 &&
     invoice.status !== "paid";
   const canReissueBilling = canEditBilling && !!invoice?.stripeInvoiceId;
+  const adjustmentBlockedByCredit =
+    adjustmentPreview?.invoicePaid === true && adjustmentPreview.priceDelta < 0;
 
   return (
     <div className="space-y-6 animate-fade-in">
@@ -371,6 +492,12 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
             <Button size="sm" variant="outline" onClick={startEditing}>
               <Pencil className="mr-2 h-4 w-4" />
               Edit
+            </Button>
+          )}
+          {["confirmed", "in_progress"].includes(data.status) && !editing && (
+            <Button size="sm" variant="outline" onClick={startWorkAdjustment}>
+              <Wrench className="mr-2 h-4 w-4" />
+              Adjust Work
             </Button>
           )}
           {editing && (
@@ -602,7 +729,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                                 [v._id]: val === "__legacy__" ? "" : val,
                               }))
                             }
-                            disabled={!checked || !vehicleTypes?.length}
+                            disabled={!checked || typedVehicleTypes.length === 0}
                           >
                             <SelectTrigger className="w-36">
                               <SelectValue />
@@ -611,7 +738,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                               <SelectItem value="__legacy__">
                                 {v.size || "medium"}
                               </SelectItem>
-                              {(vehicleTypes || []).map((vehicleType) => (
+                              {typedVehicleTypes.map((vehicleType) => (
                                 <SelectItem key={vehicleType._id} value={vehicleType._id}>
                                   {vehicleType.name}
                                 </SelectItem>
@@ -675,7 +802,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
           <CardContent>
             {editing ? (
               <div className="space-y-2">
-                {(allServices || [])
+                {allServiceOptions
                   .filter((s) => s.isActive)
                   .map((s) => {
                     const isSelected = editServiceIds.includes(s._id);
@@ -706,7 +833,9 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                       <p className="font-medium text-sm">{s.name}</p>
                       <p className="text-xs text-muted-foreground">{s.duration} min</p>
                     </div>
-                    <span className="text-sm font-medium">{formatCurrency(s.effectivePrice)}</span>
+                    <span className="text-sm font-medium">
+                      {formatCurrency(s.effectivePrice ?? s.basePrice ?? 0)}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -926,6 +1055,43 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
         </Card>
       </div>
 
+      {typedAdjustments.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Work Adjustments</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {typedAdjustments.map((adjustment) => (
+              <div
+                key={adjustment._id}
+                className="grid gap-3 rounded-md border p-3 md:grid-cols-[1fr_auto]"
+              >
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium">{adjustment.reason}</p>
+                    <Badge variant="outline" className="capitalize">
+                      {adjustment.invoiceAction.replaceAll("_", " ")}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {new Date(adjustment.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                <div className="flex gap-4 text-sm md:justify-end">
+                  <span className={adjustment.priceDelta >= 0 ? "text-green-700" : "text-red-700"}>
+                    {adjustment.priceDelta >= 0 ? "+" : ""}
+                    {formatCurrency(adjustment.priceDelta)}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {formatMinutes(adjustment.durationDelta)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
       {/* Notes */}
       {editing ? (
         <Card>
@@ -951,6 +1117,194 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
           </CardContent>
         </Card>
       ) : null}
+
+      <Dialog open={adjustingWork} onOpenChange={setAdjustingWork}>
+        <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Adjust Work</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-5">
+            <section className="space-y-3">
+              <div>
+                <Label>Vehicles</Label>
+                <p className="text-xs text-muted-foreground">
+                  Add or remove saved customer vehicles for this appointment.
+                </p>
+              </div>
+              {adjustmentVehicles.length === 0 ? (
+                <p className="rounded-md border p-3 text-sm text-muted-foreground">
+                  No customer vehicles are available.
+                </p>
+              ) : (
+                <div className="grid gap-3 md:grid-cols-2">
+                  {adjustmentVehicles.map((vehicle) => {
+                    const checked = adjustVehicleIds.includes(vehicle._id);
+                    const hasPetFee = adjustPetFeeVehicleIds.includes(vehicle._id);
+                    return (
+                      <div key={vehicle._id} className="rounded-md border p-3">
+                        <div className="flex items-start gap-3">
+                          <Checkbox
+                            checked={checked}
+                            onCheckedChange={(value) =>
+                              toggleAdjustVehicle(vehicle._id, value === true)
+                            }
+                            className="mt-1"
+                          />
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium">
+                              {vehicle.year} {vehicle.make} {vehicle.model}
+                            </p>
+                            <p className="text-xs capitalize text-muted-foreground">
+                              {vehicle.vehicleType?.name ?? vehicle.size ?? "medium"}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="mt-3 flex items-center gap-2 border-t pt-3">
+                          <Checkbox
+                            checked={hasPetFee}
+                            disabled={!checked}
+                            onCheckedChange={(value) =>
+                              toggleAdjustPetFeeVehicle(vehicle._id, value === true)
+                            }
+                          />
+                          <span className="text-sm">Pet hair fee</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+
+            <section className="space-y-3">
+              <div>
+                <Label>Services</Label>
+                <p className="text-xs text-muted-foreground">
+                  Pricing and duration recalculate from the selected vehicles.
+                </p>
+              </div>
+              <div className="grid gap-2 md:grid-cols-2">
+                {allServiceOptions
+                  .filter((service) => service.isActive)
+                  .map((service) => {
+                    const selected = adjustServiceIds.includes(service._id);
+                    return (
+                      <button
+                        type="button"
+                        key={service._id}
+                        className={`rounded-md border p-3 text-left transition-colors ${
+                          selected ? "border-primary bg-primary/5" : "hover:bg-muted/50"
+                        }`}
+                        onClick={() => toggleAdjustService(service._id)}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-medium">{service.name}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {service.duration} min
+                            </p>
+                          </div>
+                          <Checkbox checked={selected} />
+                        </div>
+                      </button>
+                    );
+                  })}
+              </div>
+            </section>
+
+            <section className="rounded-md border bg-muted/30 p-4">
+              {adjustVehicleIds.length === 0 || adjustServiceIds.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  Select at least one vehicle and one service to preview the change.
+                </p>
+              ) : adjustmentPreview === undefined ? (
+                <p className="text-sm text-muted-foreground">Calculating adjustment...</p>
+              ) : (
+                <div className="space-y-3">
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <div>
+                      <p className="text-xs text-muted-foreground">Price change</p>
+                      <p className={adjustmentPreview.priceDelta >= 0 ? "font-semibold text-green-700" : "font-semibold text-red-700"}>
+                        {adjustmentPreview.priceDelta >= 0 ? "+" : ""}
+                        {formatCurrency(adjustmentPreview.priceDelta)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">Duration change</p>
+                      <p className="font-semibold">
+                        {formatMinutes(adjustmentPreview.durationDelta)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">New total</p>
+                      <p className="font-semibold">
+                        {formatCurrency(adjustmentPreview.newTotalPrice)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    <span>
+                      {formatCurrency(adjustmentPreview.oldTotalPrice)} to{" "}
+                      {formatCurrency(adjustmentPreview.newTotalPrice)}
+                    </span>
+                    <span>
+                      {adjustmentPreview.oldDuration} min to {adjustmentPreview.newDuration} min
+                    </span>
+                    {adjustmentPreview.invoiceStatus && (
+                      <span>Invoice: {adjustmentPreview.invoiceStatus}</span>
+                    )}
+                  </div>
+                  {adjustmentPreview.invoicePaid && adjustmentPreview.priceDelta > 0 && (
+                    <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
+                      The paid invoice will stay locked. A supplemental invoice will be created for the added amount.
+                    </div>
+                  )}
+                  {adjustmentBlockedByCredit && (
+                    <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                      This lowers a paid invoice. Use a refund or credit workflow before applying this change.
+                    </div>
+                  )}
+                </div>
+              )}
+            </section>
+
+            <div className="space-y-2">
+              <Label htmlFor="adjustment-reason">Reason</Label>
+              <Textarea
+                id="adjustment-reason"
+                value={adjustReason}
+                onChange={(event) => setAdjustReason(event.target.value)}
+                placeholder="Example: added pet hair and second vehicle on arrival"
+                rows={3}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2 border-t pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setAdjustingWork(false)}
+                disabled={adjustLoading}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void handleApplyWorkAdjustment()}
+                disabled={
+                  adjustLoading ||
+                  adjustmentBlockedByCredit ||
+                  adjustVehicleIds.length === 0 ||
+                  adjustServiceIds.length === 0
+                }
+              >
+                {adjustLoading ? "Applying..." : "Apply Adjustment"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={!!previewPhoto}

--- a/components/admin/dashboard-client.tsx
+++ b/components/admin/dashboard-client.tsx
@@ -20,9 +20,19 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { formatTime12h } from "@/lib/time";
+import type { Id } from "@/convex/_generated/dataModel";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type Props = {};
+
+type PendingTripLogCard = {
+  _id: Id<"tripLogs">;
+  logDate: string;
+  appointment?: {
+    customerName?: string;
+    scheduledTime?: string;
+  } | null;
+};
 
 export default function DashboardClient({}: Props) {
   const stats = useQuery(api.analytics.getMonthlyStats) || {
@@ -189,7 +199,7 @@ export default function DashboardClient({}: Props) {
             </div>
           ) : (
             <div className="space-y-3">
-              {pendingTripLogs.map((log) => (
+              {pendingTripLogs.map((log: PendingTripLogCard) => (
                 <div
                   key={log._id}
                   className="flex items-center justify-between p-3 rounded-lg border border-border"

--- a/components/admin/invoice-detail-client.tsx
+++ b/components/admin/invoice-detail-client.tsx
@@ -47,6 +47,13 @@ type Props = {
   invoiceId: Id<"invoices">;
 };
 
+type InvoiceLineItem = {
+  serviceName: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+};
+
 function getStatusBadge(status: string) {
   const variants: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
     draft: "outline",
@@ -417,7 +424,7 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {invoice.items.map((item, index) => (
+              {invoice.items.map((item: InvoiceLineItem, index: number) => (
                 <TableRow key={index}>
                   <TableCell className="font-medium">{item.serviceName}</TableCell>
                   <TableCell className="text-right">{item.quantity}</TableCell>

--- a/components/admin/payment-detail-client.tsx
+++ b/components/admin/payment-detail-client.tsx
@@ -38,6 +38,13 @@ type Props = {
   invoiceId: Id<"invoices">;
 };
 
+type InvoiceLineItem = {
+  serviceName: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+};
+
 const STATUS_STYLES: Record<string, string> = {
   draft: "bg-gray-100 text-gray-700",
   sent: "bg-yellow-100 text-yellow-700",
@@ -314,7 +321,7 @@ export default function PaymentDetailClient({ invoiceId }: Props) {
               </tr>
             </thead>
             <tbody className="divide-y">
-              {invoice.items.map((item, index) => (
+              {invoice.items.map((item: InvoiceLineItem, index: number) => (
                 <tr key={index}>
                   <td className="p-3">{item.serviceName}</td>
                   <td className="p-3 text-center">{item.quantity}</td>

--- a/components/admin/payments-client.tsx
+++ b/components/admin/payments-client.tsx
@@ -66,6 +66,21 @@ interface Invoice {
   remainingBalance?: number;
 }
 
+type AbandonedDraftRow = {
+  _id: Id<"bookingDrafts">;
+  name: string;
+  email: string;
+  phone?: string;
+  serviceNames: string[];
+  scheduledDate: string;
+  scheduledTime: string;
+  status: string;
+  recovered?: boolean;
+  resumeToken: string;
+  abandonedEmailSentAt?: number;
+  lastActivityAt: number;
+};
+
 type InvoiceStatus = "draft" | "sent" | "paid" | "overdue";
 
 type InvoiceRecord = Invoice & {
@@ -141,7 +156,7 @@ function InvoicePreview({ invoice }: { invoice: Invoice }) {
           </tr>
         </thead>
         <tbody className="divide-y">
-          {invoice.items.map((item, index) => (
+          {invoice.items.map((item: InvoiceItem, index: number) => (
             <tr key={index}>
               <td className="p-2">{item.serviceName}</td>
               <td className="p-2 text-center">{item.quantity}</td>
@@ -529,7 +544,7 @@ export default function PaymentsClient() {
                   </tr>
                 </thead>
                 <tbody>
-                  {abandonedItems.map((draft) => (
+                  {abandonedItems.map((draft: AbandonedDraftRow) => (
                     <tr key={draft._id} className="border-b last:border-b-0">
                       <td className="py-3 pr-4">
                         <div className="font-medium">{draft.name}</div>

--- a/components/admin/subscriptions-client.tsx
+++ b/components/admin/subscriptions-client.tsx
@@ -106,6 +106,16 @@ type CustomerVehicle = {
   size?: "small" | "medium" | "large";
 };
 
+type SubscriptionServiceOption = {
+  _id: Id<"services">;
+  name: string;
+  isActive: boolean;
+  serviceType?: string;
+  basePrice?: number;
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+};
+
 function statusVariant(status: string) {
   switch (status) {
     case "active":
@@ -426,7 +436,7 @@ function CreateSubscriptionForm({ onSuccess }: { onSuccess: () => void }) {
   const customers = useQuery(api.users.listWithStats) as
     | CustomerOption[]
     | undefined;
-  const services = useQuery(api.services.list);
+  const services = useQuery(api.services.list) as SubscriptionServiceOption[] | undefined;
   const createSubscription = useMutation(api.subscriptions.create);
 
   const [selectedCustomerId, setSelectedCustomerId] = useState("");

--- a/components/admin/webhook-health-client.tsx
+++ b/components/admin/webhook-health-client.tsx
@@ -6,6 +6,51 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { AlertCircle, ShieldAlert } from "lucide-react";
 
+type WebhookDiagnosticsOverview = {
+  counts: {
+    paidDepositsMissingStripeInvoice: number;
+    paidGuestInvoicesMissingClerkAccount: number;
+    paidInvoicesMissingStripeEvidence: number;
+    usersMissingStripeCustomer: number;
+  };
+  paidGuestInvoicesMissingClerkAccount: Array<{
+    invoiceId: string;
+    customerName: string;
+    customerEmail: string;
+    invoiceNumber: string;
+    appointmentStatus: string;
+    latestSyncAt: number | null;
+    latestSyncResult?: string | null;
+    latestSyncMessage?: string | null;
+  }>;
+  paidDepositsMissingStripeInvoice: Array<{
+    invoiceId: string;
+    customerName: string;
+    invoiceNumber: string;
+    appointmentStatus: string;
+    invoiceGenerationError?: string | null;
+  }>;
+  paidInvoicesMissingStripeEvidence: Array<{
+    invoiceId: string;
+    customerName: string;
+    customerEmail: string;
+    invoiceNumber: string;
+  }>;
+  recentIssues: Array<{
+    id: string;
+    level: "warning" | "error";
+    source: string;
+    eventType: string;
+    message: string;
+    createdAt: number;
+  }>;
+  usersMissingStripeCustomer: Array<{
+    userId: string;
+    customerName: string;
+    customerEmail: string;
+  }>;
+};
+
 function formatEventTime(timestamp: number | null) {
   if (!timestamp) {
     return "No sync recorded";
@@ -14,7 +59,9 @@ function formatEventTime(timestamp: number | null) {
 }
 
 export default function WebhookHealthClient() {
-  const diagnostics = useQuery(api.webhookDiagnostics.getAdminOverview);
+  const diagnostics = useQuery(
+    api.webhookDiagnostics.getAdminOverview,
+  ) as WebhookDiagnosticsOverview | undefined;
 
   if (!diagnostics) {
     return (

--- a/components/booking/booking-flow.tsx
+++ b/components/booking/booking-flow.tsx
@@ -11,6 +11,7 @@ import {
   getEffectiveServicePricingForVehicle,
   isServiceAvailableForVehicle,
   normalizeServiceType,
+  type ServiceType,
   type VehicleSize,
 } from "@/convex/lib/pricing";
 import { isArkansasState, normalizeStateCode } from "@/convex/lib/address";
@@ -76,6 +77,31 @@ interface RadarAddress {
   latitude?: number;
   longitude?: number;
 }
+
+type BookingService = {
+  _id: Id<"services">;
+  name: string;
+  description: string;
+  categoryName?: string;
+  serviceType?: ServiceType;
+  isActive: boolean;
+  basePrice?: number;
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+  basePriceLarge?: number;
+  duration?: number;
+  durationSmall?: number;
+  durationMedium?: number;
+  durationLarge?: number;
+  vehiclePrices?: Array<{
+    vehicleTypeId: Id<"vehicleTypes">;
+    price: number;
+    isAvailable: boolean;
+    duration?: number;
+  }>;
+  bookableVehicleTypeIds?: Id<"vehicleTypes">[];
+  bookableLegacySizes?: Array<"small" | "medium" | "large">;
+};
 
 const step1Schema = z.object({
   scheduledDate: z.date({
@@ -218,7 +244,7 @@ export default function BookingFlow() {
     },
   });
 
-  const services = useQuery(api.services.list);
+  const services = useQuery(api.services.list) as BookingService[] | undefined;
   const petFeeSettings = useQuery(api.petFeeSettings.get);
   const depositSettings = useQuery(api.depositSettings.get);
   const bookingReadiness = useQuery(api.setupReadiness.getPublicBookingReadiness);

--- a/components/dashboard/dashboard-client.tsx
+++ b/components/dashboard/dashboard-client.tsx
@@ -56,6 +56,15 @@ type RawAppointment = {
   createdBy: Id<"users">;
 };
 
+type UserVehicleCard = {
+  _id: Id<"vehicles">;
+  year: number;
+  make: string;
+  model: string;
+  color?: string;
+  size?: string;
+};
+
 const STATUS_STYLES: Record<string, string> = {
   pending: "bg-yellow-100 text-yellow-700",
   confirmed: "bg-green-100 text-green-700",
@@ -172,7 +181,7 @@ export default function DashboardClient() {
 
   const upcomingAppointments = (userAppointmentsQuery?.upcoming ?? []) as RawAppointment[];
   const currentUser = currentUserQuery ?? null;
-  const userVehicles = userVehiclesQuery ?? [];
+  const userVehicles = (userVehiclesQuery ?? []) as UserVehicleCard[];
   const completedAppointments = userAppointmentsQuery?.past || [];
   const nextAppointment = upcomingAppointments[0] as RawAppointment | undefined;
   const remainingAppointments = upcomingAppointments.slice(1) as RawAppointment[];

--- a/components/dashboard/invoices-client.tsx
+++ b/components/dashboard/invoices-client.tsx
@@ -386,7 +386,7 @@ export default function InvoicesClient() {
     );
   }
 
-  const invoices = invoicesQuery ?? [];
+  const invoices = (invoicesQuery ?? []) as Invoice[];
 
   const getStatusBadge = (status: string) => {
     switch (status) {

--- a/components/dashboard/subscriptions-client.tsx
+++ b/components/dashboard/subscriptions-client.tsx
@@ -15,6 +15,17 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import Link from "next/link";
+import type { Id } from "@/convex/_generated/dataModel";
+
+type SubscriptionCard = {
+  _id: Id<"subscriptions">;
+  serviceNames: string[];
+  vehicleNames: string[];
+  status: string;
+  frequency: "biweekly" | "monthly";
+  totalPrice: number;
+  nextScheduledDate?: string;
+};
 
 function statusVariant(status: string) {
   switch (status) {
@@ -52,7 +63,9 @@ function formatCurrency(amount: number) {
 }
 
 export default function SubscriptionsClient() {
-  const subscriptions = useQuery(api.subscriptions.getByUser);
+  const subscriptions = useQuery(
+    api.subscriptions.getByUser,
+  ) as SubscriptionCard[] | undefined | null;
   const createPortalSession = useAction(api.subscriptions.createCustomerPortalSession);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/components/dashboard/vehicles-client.tsx
+++ b/components/dashboard/vehicles-client.tsx
@@ -47,6 +47,12 @@ type Vehicle = {
   } | null;
 };
 
+type VehicleAppointmentStat = {
+  vehicleIds: Id<"vehicles">[];
+  status: string;
+  scheduledDate: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface VehiclesClientProps {}
 
@@ -56,11 +62,12 @@ export default function VehiclesClient({}: VehiclesClientProps) {
   // Always call hooks at the top level - never conditionally
   const vehiclesQuery = useQuery(api.vehicles.getMyVehicles);
   const currentUser = useQuery(api.users.getCurrentUser);
-  const userAppointments =
+  const userAppointments = (
     useQuery(
       api.appointments.getByUser,
       currentUser?._id ? { userId: currentUser._id } : "skip",
-    ) || [];
+    ) || []
+  ) as VehicleAppointmentStat[];
 
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [bookingVehicleId, setBookingVehicleId] = useState<string | null>(null);

--- a/components/forms/admin/add-appointment-form.tsx
+++ b/components/forms/admin/add-appointment-form.tsx
@@ -56,6 +56,39 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
+type ClientOption = {
+  _id: Id<"users">;
+  name?: string;
+  email?: string;
+  role?: string;
+  address?: {
+    street?: string;
+    city?: string;
+    state?: string;
+    zip?: string;
+  };
+};
+
+type AdminVehicleOption = {
+  _id: Id<"vehicles">;
+  year: number;
+  make: string;
+  model: string;
+  color?: string;
+  size?: string;
+};
+
+type AdminServiceOption = {
+  _id: Id<"services">;
+  name: string;
+  duration?: number;
+  isActive: boolean;
+  basePrice?: number;
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+  basePriceLarge?: number;
+};
+
 interface AddAppointmentFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -78,8 +111,8 @@ export function AddAppointmentForm({
     notes: "",
   });
 
-  const clients = useQuery(api.users.list);
-  const services = useQuery(api.services.list);
+  const clients = useQuery(api.users.list) as ClientOption[] | undefined;
+  const services = useQuery(api.services.list) as AdminServiceOption[] | undefined;
   const petFeeSettings = useQuery(api.petFeeSettings.get);
   const createAppointment = useMutation(api.appointments.create);
   const createVehicle = useMutation(api.vehicles.create);
@@ -107,7 +140,7 @@ export function AddAppointmentForm({
   const userVehicles = useQuery(
     api.vehicles.getByUser,
     selectedUserId ? { userId: selectedUserId as Id<"users"> } : "skip",
-  );
+  ) as AdminVehicleOption[] | undefined;
 
   const schedulingDuration = useMemo(() => {
     const selectedServices =

--- a/components/forms/admin/add-service-form.tsx
+++ b/components/forms/admin/add-service-form.tsx
@@ -62,6 +62,11 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
+type IncludedServiceOption = {
+  _id: Id<"services">;
+  name: string;
+};
+
 interface AddServiceFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -78,7 +83,9 @@ export function AddServiceForm({
   const [isLoading, setIsLoading] = useState(false);
   const [newFeature, setNewFeature] = useState("");
 
-  const allServices = useQuery(api.services.list);
+  const allServices = useQuery(api.services.list) as
+    | IncludedServiceOption[]
+    | undefined;
   const createService = useMutation(api.services.create);
 
   const form = useForm<FormData>({

--- a/components/forms/admin/edit-service-form.tsx
+++ b/components/forms/admin/edit-service-form.tsx
@@ -64,6 +64,27 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
+type EditableService = {
+  _id: Id<"services">;
+  name: string;
+  description: string;
+  duration: number;
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+  basePriceLarge?: number;
+  vehiclePrices?: Array<{
+    vehicleTypeId?: Id<"vehicleTypes">;
+    price: number;
+    duration?: number;
+    isAvailable: boolean;
+  }>;
+  features?: string[];
+  icon?: string;
+  includedServiceIds?: Id<"services">[];
+  isActive: boolean;
+  serviceType?: "standard" | "addon" | "subscription";
+};
+
 interface EditServiceFormProps {
   serviceId: Id<"services"> | null;
   open: boolean;
@@ -78,11 +99,11 @@ export function EditServiceForm({
   const [isLoading, setIsLoading] = useState(false);
   const [newFeature, setNewFeature] = useState("");
 
-  const allServices = useQuery(api.services.list);
+  const allServices = useQuery(api.services.list) as EditableService[] | undefined;
   const service = useQuery(
     api.services.getById,
     serviceId ? { serviceId } : "skip",
-  );
+  ) as EditableService | undefined | null;
   const updateService = useMutation(api.services.update);
 
   const form = useForm<FormData>({

--- a/components/forms/admin/service-editor.tsx
+++ b/components/forms/admin/service-editor.tsx
@@ -79,6 +79,35 @@ type ServiceEditorProps = {
   initialType?: ServiceEditorType;
 };
 
+type ServiceEditorRecord = {
+  _id: Id<"services">;
+  name: string;
+  description: string;
+  duration: number;
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+  basePriceLarge?: number;
+  vehiclePrices?: Array<{
+    vehicleTypeId?: Id<"vehicleTypes">;
+    price: number;
+    duration?: number;
+    isAvailable: boolean;
+  }>;
+  features?: string[];
+  icon?: string;
+  categoryId?: Id<"serviceCategories">;
+  includedServiceIds?: Id<"services">[];
+  isActive: boolean;
+  showOnLandingPage?: boolean;
+  serviceType?: ServiceEditorType;
+};
+
+type ServiceCategoryOption = {
+  _id: Id<"serviceCategories">;
+  name: string;
+  type: ServiceEditorType;
+};
+
 const TYPE_LABELS: Record<ServiceEditorType, string> = {
   standard: "Standard service",
   addon: "Add-on",
@@ -93,12 +122,16 @@ export function ServiceEditor({
   const router = useRouter();
   const [isSaving, setIsSaving] = useState(false);
   const [newFeature, setNewFeature] = useState("");
-  const allServices = useQuery(api.services.list);
-  const categories = useQuery(api.services.listCategories);
+  const allServices = useQuery(api.services.list) as
+    | ServiceEditorRecord[]
+    | undefined;
+  const categories = useQuery(api.services.listCategories) as
+    | ServiceCategoryOption[]
+    | undefined;
   const service = useQuery(
     api.services.getById,
     mode === "edit" && serviceId ? { serviceId } : "skip",
-  );
+  ) as ServiceEditorRecord | undefined | null;
   const createService = useMutation(api.services.create);
   const updateService = useMutation(api.services.update);
   const serviceType =

--- a/components/forms/admin/vehicle-pricing-editor.tsx
+++ b/components/forms/admin/vehicle-pricing-editor.tsx
@@ -30,6 +30,11 @@ type FormWithVehiclePrices = {
   vehiclePrices: VehiclePriceFormRow[];
 };
 
+type VehicleTypeOption = {
+  _id: string;
+  name: string;
+};
+
 interface VehiclePricingEditorProps<TForm extends FormWithVehiclePrices> {
   form: UseFormReturn<TForm>;
   defaultDuration: number;
@@ -39,7 +44,9 @@ export function VehiclePricingEditor<TForm extends FormWithVehiclePrices>({
   form,
   defaultDuration,
 }: VehiclePricingEditorProps<TForm>) {
-  const vehicleTypes = useQuery(api.vehicleTypes.list, {});
+  const vehicleTypes = useQuery(api.vehicleTypes.list, {}) as
+    | VehicleTypeOption[]
+    | undefined;
   const ensureDefaults = useMutation(api.vehicleTypes.ensureDefaults);
   const createVehicleType = useMutation(api.vehicleTypes.create);
   const [newTypeNameByRow, setNewTypeNameByRow] = useState<Record<number, string>>({});

--- a/components/forms/dashboard/dashboard-appointment-form.tsx
+++ b/components/forms/dashboard/dashboard-appointment-form.tsx
@@ -9,6 +9,7 @@ import {
   getEffectiveServicePricingForVehicle,
   isServiceAvailableForVehicle,
   normalizeServiceType,
+  type ServiceType,
 } from "@/convex/lib/pricing";
 import { calculateSchedulingDuration } from "@/convex/lib/booking";
 import type { VehicleSize } from "@/convex/lib/pricing";
@@ -76,6 +77,41 @@ interface RadarAddress {
   };
 }
 
+type DashboardVehicleOption = {
+  _id: Id<"vehicles">;
+  year: number;
+  make: string;
+  model: string;
+  color?: string;
+  licensePlate?: string;
+  size?: "small" | "medium" | "large";
+  vehicleTypeId?: Id<"vehicleTypes">;
+};
+
+type DashboardServiceOption = {
+  _id: Id<"services">;
+  name: string;
+  description: string;
+  serviceType?: ServiceType;
+  isActive: boolean;
+  basePrice?: number;
+  basePriceSmall?: number;
+  basePriceMedium?: number;
+  basePriceLarge?: number;
+  duration?: number;
+  durationSmall?: number;
+  durationMedium?: number;
+  durationLarge?: number;
+  vehiclePrices?: Array<{
+    vehicleTypeId: Id<"vehicleTypes">;
+    price: number;
+    isAvailable: boolean;
+    duration?: number;
+  }>;
+  bookableVehicleTypeIds?: Id<"vehicleTypes">[];
+  bookableLegacySizes?: Array<"small" | "medium" | "large">;
+};
+
 export function DashboardAppointmentForm({
   open,
   onOpenChange,
@@ -113,8 +149,12 @@ export function DashboardAppointmentForm({
 
   // Queries
   const currentUser = useQuery(api.users.getCurrentUser);
-  const userVehicles = useQuery(api.vehicles.getMyVehicles);
-  const services = useQuery(api.services.list);
+  const userVehicles = useQuery(api.vehicles.getMyVehicles) as
+    | DashboardVehicleOption[]
+    | undefined;
+  const services = useQuery(api.services.list) as
+    | DashboardServiceOption[]
+    | undefined;
   const petFeeSettings = useQuery(api.petFeeSettings.get);
   const nextBookableDate = useQuery(api.availability.getNextBookableDate, {});
 

--- a/components/forms/dashboard/schedule-appointment-form.tsx
+++ b/components/forms/dashboard/schedule-appointment-form.tsx
@@ -52,6 +52,26 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
+type ScheduleClientOption = {
+  _id: Id<"users">;
+  name?: string;
+  email?: string;
+};
+
+type ScheduleVehicleOption = {
+  _id: Id<"vehicles">;
+  year: number;
+  make: string;
+  model: string;
+};
+
+type ScheduleServiceOption = {
+  _id: Id<"services">;
+  name: string;
+  isActive: boolean;
+  basePrice?: number;
+};
+
 interface AddAppointmentFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -63,8 +83,10 @@ export function ScheduleAppointmentForm({
 }: AddAppointmentFormProps) {
   const [isLoading, setIsLoading] = useState(false);
 
-  const clients = useQuery(api.users.list);
-  const services = useQuery(api.services.list);
+  const clients = useQuery(api.users.list) as ScheduleClientOption[] | undefined;
+  const services = useQuery(api.services.list) as
+    | ScheduleServiceOption[]
+    | undefined;
   const nextBookableDate = useQuery(api.availability.getNextBookableDate, {});
   const createAppointment = useMutation(api.appointments.create);
 
@@ -89,7 +111,7 @@ export function ScheduleAppointmentForm({
   const userVehicles = useQuery(
     api.vehicles.getByUser,
     selectedUserId ? { userId: selectedUserId as Id<"users"> } : "skip",
-  );
+  ) as ScheduleVehicleOption[] | undefined;
 
   useEffect(() => {
     if (!open || !nextBookableDate) {

--- a/components/home/pricing.tsx
+++ b/components/home/pricing.tsx
@@ -10,9 +10,30 @@ import { motion } from "motion/react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
+type LandingPricingService = {
+  _id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  features?: string[];
+  price: number;
+  duration: number;
+};
+
+type LandingPricingGroup = {
+  vehicleType: {
+    _id: string;
+    name: string;
+  };
+  services: LandingPricingService[];
+};
+
 export function PricingSection() {
   const router = useRouter();
-  const pricingQuery = useQuery(api.services.listLandingPagePricing);
+  const pricingQuery = useQuery(api.services.listLandingPagePricing) as
+    | LandingPricingGroup[]
+    | undefined
+    | null;
   const bookingReadiness = useQuery(
     api.setupReadiness.getPublicBookingReadiness,
   );

--- a/components/home/time-slot-picker.tsx
+++ b/components/home/time-slot-picker.tsx
@@ -38,7 +38,7 @@ export function TimeSlotPicker({
     date: date || "",
     serviceDuration,
     ignoreAppointmentId,
-  });
+  }) as TimeSlot[] | undefined;
 
   // No date selected — show disabled placeholder
   if (!date) {

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -22,6 +22,141 @@ async function expectConvexErrorCode(
 }
 
 describe("appointments", () => {
+  async function createAdjustmentFixture(
+    t: any,
+    options: { invoiceStatus?: "draft" | "open" | "paid"; depositPaid?: boolean } = {},
+  ) {
+    await seedBookingSetup(t, {
+      includeBookableService: false,
+      includeDepositSettings: true,
+    });
+
+    const {
+      adminId,
+      userId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+      addOnServiceId,
+      cheaperServiceId,
+    } = await t.run(async (ctx: any) => {
+      const adminId = await ctx.db.insert("users", {
+        name: "Adjustment Admin",
+        email: "adjustment-admin@example.com",
+        role: "admin",
+      });
+      const userId = await ctx.db.insert("users", {
+        name: "Adjustment Customer",
+        email: "adjustment-customer@example.com",
+        role: "client",
+        timesServiced: 0,
+        totalSpent: 0,
+        status: "active",
+      });
+      const vehicleId = await ctx.db.insert("vehicles", {
+        userId,
+        year: 2020,
+        make: "Toyota",
+        model: "Camry",
+        size: "medium",
+      });
+      const secondVehicleId = await ctx.db.insert("vehicles", {
+        userId,
+        year: 2024,
+        make: "Honda",
+        model: "Pilot",
+        size: "large",
+      });
+      const baseServiceId = await ctx.db.insert("services", {
+        name: "Level 2 Detail",
+        description: "Base detail",
+        basePrice: 100,
+        basePriceMedium: 100,
+        basePriceLarge: 150,
+        duration: 120,
+        serviceType: "standard",
+        isActive: true,
+      });
+      const addOnServiceId = await ctx.db.insert("services", {
+        name: "Interior Add-On",
+        description: "Added interior work",
+        basePrice: 60,
+        basePriceMedium: 60,
+        basePriceLarge: 80,
+        duration: 45,
+        serviceType: "standard",
+        isActive: true,
+      });
+      const cheaperServiceId = await ctx.db.insert("services", {
+        name: "Quick Wash",
+        description: "Lower priced work",
+        basePrice: 40,
+        basePriceMedium: 40,
+        basePriceLarge: 60,
+        duration: 45,
+        serviceType: "standard",
+        isActive: true,
+      });
+      await ctx.db.insert("petFeeSettings", {
+        basePriceSmall: 25,
+        basePriceMedium: 50,
+        basePriceLarge: 75,
+        timeAddMinutes: 30,
+        isActive: true,
+      });
+      return {
+        adminId,
+        userId,
+        vehicleId,
+        secondVehicleId,
+        baseServiceId,
+        addOnServiceId,
+        cheaperServiceId,
+      };
+    });
+
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "adjustment-admin@example.com",
+    });
+    const { appointmentId, invoiceId } = await asAdmin.mutation(
+      api.appointments.create,
+      {
+        userId,
+        vehicleIds: [vehicleId],
+        serviceIds: [baseServiceId],
+        scheduledDate: APPOINTMENT_TEST_DATE,
+        scheduledTime: "10:00",
+        street: "123 Main St",
+        city: "Little Rock",
+        state: "AR",
+        zip: "72205",
+      },
+    );
+
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(appointmentId, { status: "confirmed" });
+      await ctx.db.patch(invoiceId, {
+        status: options.invoiceStatus ?? "draft",
+        depositPaid: options.depositPaid ?? false,
+        depositAmount: options.depositPaid ? 50 : 0,
+        remainingBalance: options.depositPaid ? 50 : 100,
+      });
+    });
+
+    return {
+      asAdmin,
+      appointmentId,
+      invoiceId,
+      userId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+      addOnServiceId,
+      cheaperServiceId,
+    };
+  }
+
   test("appointment details include signed before photo URLs", async () => {
     const t = convexTest(schema, modules);
     const { appointmentId, adminId } = await t.run(async (ctx) => {
@@ -297,7 +432,7 @@ describe("appointments", () => {
       const appointment = await ctx.db.get(appointmentId);
       const invoice = await ctx.db
         .query("invoices")
-        .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
+        .withIndex("by_appointment", (q: any) => q.eq("appointmentId", appointmentId))
         .unique();
       return { appointment, invoice };
     });
@@ -343,7 +478,7 @@ describe("appointments", () => {
       const appointment = await ctx.db.get(appointmentId);
       const invoice = await ctx.db
         .query("invoices")
-        .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
+        .withIndex("by_appointment", (q: any) => q.eq("appointmentId", appointmentId))
         .unique();
       return { appointment, invoice };
     });
@@ -359,6 +494,167 @@ describe("appointments", () => {
         totalPrice: 75,
       }),
     ]);
+  });
+
+  test("work adjustment updates an unpaid invoice and records an audit snapshot", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      invoiceId,
+      vehicleId,
+      baseServiceId,
+    } = await createAdjustmentFixture(t);
+
+    const result = await asAdmin.mutation(api.appointments.applyWorkAdjustment, {
+      appointmentId,
+      vehicleIds: [vehicleId],
+      serviceIds: [baseServiceId],
+      petFeeVehicleIds: [vehicleId],
+      reason: "Pet hair found on arrival",
+    });
+
+    expect(result.invoiceAction).toBe("updated_open_invoice");
+
+    const updated = await t.run(async (ctx: any) => {
+      const appointment = await ctx.db.get(appointmentId) as any;
+      const invoice = await ctx.db.get(invoiceId) as any;
+      const adjustments = await ctx.db
+        .query("appointmentAdjustments")
+        .withIndex("by_appointment", (q: any) => q.eq("appointmentId", appointmentId))
+        .collect();
+      return { appointment, invoice, adjustments };
+    });
+
+    expect(updated.appointment?.totalPrice).toBe(150);
+    expect(updated.appointment?.duration).toBe(150);
+    expect(updated.appointment?.petFeeVehicleIds).toEqual([vehicleId]);
+    expect(updated.invoice?.total).toBe(150);
+    expect(updated.invoice?.remainingBalance).toBe(150);
+    expect(updated.invoice?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "pet_fee",
+          totalPrice: 50,
+        }),
+      ]),
+    );
+    expect(updated.adjustments).toHaveLength(1);
+    expect(updated.adjustments[0]).toMatchObject({
+      reason: "Pet hair found on arrival",
+      priceDelta: 50,
+      durationDelta: 30,
+      invoiceAction: "updated_open_invoice",
+    });
+  });
+
+  test("work adjustment can add another saved vehicle", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+    } = await createAdjustmentFixture(t);
+
+    const preview = await asAdmin.query(api.appointments.previewWorkAdjustment, {
+      appointmentId,
+      vehicleIds: [vehicleId, secondVehicleId],
+      serviceIds: [baseServiceId],
+      petFeeVehicleIds: [],
+      reason: "Second vehicle added",
+    });
+    expect(preview.priceDelta).toBe(150);
+    expect(preview.durationDelta).toBe(120);
+
+    await asAdmin.mutation(api.appointments.applyWorkAdjustment, {
+      appointmentId,
+      vehicleIds: [vehicleId, secondVehicleId],
+      serviceIds: [baseServiceId],
+      petFeeVehicleIds: [],
+      reason: "Second vehicle added",
+    });
+
+    const appointment = await t.run(
+      async (ctx: any) => (await ctx.db.get(appointmentId)) as any,
+    );
+    expect(appointment?.vehicleIds).toEqual([vehicleId, secondVehicleId]);
+    expect(appointment?.totalPrice).toBe(250);
+    expect(appointment?.duration).toBe(240);
+  });
+
+  test("work adjustment creates a supplemental invoice for paid invoice increases", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      vehicleId,
+      baseServiceId,
+      addOnServiceId,
+    } = await createAdjustmentFixture(t, {
+      invoiceStatus: "paid",
+      depositPaid: true,
+    });
+
+    const result = await asAdmin.mutation(api.appointments.applyWorkAdjustment, {
+      appointmentId,
+      vehicleIds: [vehicleId],
+      serviceIds: [baseServiceId, addOnServiceId],
+      petFeeVehicleIds: [],
+      reason: "Customer approved interior add-on",
+    });
+
+    expect(result.invoiceAction).toBe("supplemental_invoice_created");
+    expect(result.supplementalInvoiceId).toBeDefined();
+
+    const invoices = await t.run(async (ctx) =>
+      ctx.db
+        .query("invoices")
+        .withIndex("by_appointment", (q: any) => q.eq("appointmentId", appointmentId))
+        .collect(),
+    );
+
+    expect(invoices).toHaveLength(2);
+    const supplemental = invoices.find((invoice) => invoice._id === result.supplementalInvoiceId);
+    expect(supplemental).toMatchObject({
+      status: "draft",
+      subtotal: 60,
+      total: 60,
+      remainingBalance: 60,
+      depositPaid: true,
+    });
+  });
+
+  test("work adjustment blocks reductions on paid invoices", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      vehicleId,
+      cheaperServiceId,
+    } = await createAdjustmentFixture(t, {
+      invoiceStatus: "paid",
+      depositPaid: true,
+    });
+
+    await expect(
+      asAdmin.mutation(api.appointments.applyWorkAdjustment, {
+        appointmentId,
+        vehicleIds: [vehicleId],
+        serviceIds: [cheaperServiceId],
+        petFeeVehicleIds: [],
+        reason: "Customer downgraded package",
+      }),
+    ).rejects.toThrow("refund or credit");
+
+    const adjustments = await t.run(async (ctx) =>
+      ctx.db
+        .query("appointmentAdjustments")
+        .withIndex("by_appointment", (q: any) => q.eq("appointmentId", appointmentId))
+        .collect(),
+    );
+    expect(adjustments).toHaveLength(0);
   });
 
   test("list appointments", async () => {

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -27,6 +27,26 @@ interface StripeInvoiceVehicleInput {
   size?: "small" | "medium" | "large";
 }
 
+type InvoiceItem = {
+  itemType?: "service" | "pet_fee" | "travel_fee";
+  serviceId?: Id<"services">;
+  vehicleId?: Id<"vehicles">;
+  vehicleLabel?: string;
+  vehicleTypeId?: Id<"vehicleTypes">;
+  serviceName: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+};
+
+const workAdjustmentArgs = {
+  appointmentId: v.id("appointments"),
+  vehicleIds: v.array(v.id("vehicles")),
+  serviceIds: v.array(v.id("services")),
+  petFeeVehicleIds: v.optional(v.array(v.id("vehicles"))),
+  reason: v.string(),
+} as const;
+
 function getVehicleSize(
   vehicles: Array<StripeInvoiceVehicleInput>,
 ): "small" | "medium" | "large" {
@@ -157,6 +177,62 @@ async function buildVehicleServiceItems(
   }
 
   return { items, duration };
+}
+
+async function buildAdjustmentPricing(
+  ctx: any,
+  vehicleIds: Id<"vehicles">[],
+  serviceIds: Id<"services">[],
+  petFeeVehicleIds: Id<"vehicles">[],
+) {
+  if (vehicleIds.length === 0) {
+    throw new ConvexError({
+      code: "SERVICE_NOT_BOOKABLE",
+      message: "Select at least one vehicle.",
+    });
+  }
+  if (serviceIds.length === 0) {
+    throw new ConvexError({
+      code: "SERVICE_NOT_BOOKABLE",
+      message: "Select at least one service.",
+    });
+  }
+
+  const vehicles = (
+    await Promise.all(vehicleIds.map((id) => ctx.db.get(id)))
+  ).filter((vehicle): vehicle is Doc<"vehicles"> => vehicle !== null);
+  if (vehicles.length !== vehicleIds.length) {
+    throw new Error("One or more vehicles not found");
+  }
+
+  const vehicleSize = getVehicleSize(vehicles);
+  const services = (
+    await Promise.all(serviceIds.map((id) => ctx.db.get(id)))
+  ).filter((service): service is Doc<"services"> => service !== null);
+  if (services.length !== serviceIds.length) {
+    throw new Error("One or more services not found");
+  }
+  assertBookableServices(services, serviceIds, vehicleSize);
+
+  const selectedVehicleIdSet = new Set(vehicleIds);
+  if (petFeeVehicleIds.some((vehicleId) => !selectedVehicleIdSet.has(vehicleId))) {
+    throw new ConvexError({
+      code: "SERVICE_NOT_BOOKABLE",
+      message: "Pet fee vehicles must be included in this appointment.",
+    });
+  }
+
+  const servicePricing = await buildVehicleServiceItems(ctx, services, vehicles);
+  const petFee = await buildPetFeeItems(ctx, vehicles, petFeeVehicleIds);
+  const items: InvoiceItem[] = [...servicePricing.items, ...petFee.items];
+  const totalPrice = items.reduce((sum, item) => sum + item.totalPrice, 0);
+  const duration = calculateSchedulingDuration({
+    serviceDurations: [servicePricing.duration],
+    petFeeVehicleCount: petFee.petFeeVehicleCount,
+    petFeeTimeMinutes: petFee.petFeeTimeMinutes,
+  });
+
+  return { items, totalPrice, duration, vehicles };
 }
 
 function shouldScheduleNotificationJobs(): boolean {
@@ -330,7 +406,17 @@ export const repairMissingVehicleReferences = mutation({
     unresolved: v.number(),
     dryRun: v.boolean(),
   }),
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    scanned: number;
+    candidates: number;
+    cleanedStaleReferences: number;
+    reattachedAppointments: number;
+    unresolved: number;
+    dryRun: boolean;
+  }> => {
     await requireAdmin(ctx);
 
     const dryRun = args.dryRun ?? true;
@@ -932,7 +1018,7 @@ export const update = mutation({
     const invoice = await ctx.db
       .query("invoices")
       .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
-      .unique();
+      .first();
 
     if (invoice) {
       const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0);
@@ -986,6 +1072,254 @@ export const update = mutation({
   },
 });
 
+export const previewWorkAdjustment = query({
+  args: workAdjustmentArgs,
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const appointment = await ctx.db.get(args.appointmentId);
+    if (!appointment) throw new Error("Appointment not found");
+
+    const oldPetFeeVehicleIds = appointment.petFeeVehicleIds ?? [];
+    const oldPricing = await buildAdjustmentPricing(
+      ctx,
+      appointment.vehicleIds,
+      appointment.serviceIds,
+      oldPetFeeVehicleIds,
+    );
+    const newPricing = await buildAdjustmentPricing(
+      ctx,
+      args.vehicleIds,
+      args.serviceIds,
+      args.petFeeVehicleIds ?? [],
+    );
+    const invoice = await ctx.db
+      .query("invoices")
+      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
+      .first();
+
+    return {
+      oldTotalPrice: appointment.totalPrice,
+      newTotalPrice: newPricing.totalPrice,
+      priceDelta: newPricing.totalPrice - appointment.totalPrice,
+      oldDuration: appointment.duration,
+      newDuration: newPricing.duration,
+      durationDelta: newPricing.duration - appointment.duration,
+      oldItems: oldPricing.items,
+      newItems: newPricing.items,
+      invoiceStatus: invoice?.status ?? null,
+      invoicePaid: invoice?.status === "paid",
+    };
+  },
+});
+
+export const listAdjustments = query({
+  args: { appointmentId: v.id("appointments") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    return await ctx.db
+      .query("appointmentAdjustments")
+      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
+      .order("desc")
+      .collect();
+  },
+});
+
+export const applyWorkAdjustment = mutation({
+  args: workAdjustmentArgs,
+  returns: v.object({
+    adjustmentId: v.id("appointmentAdjustments"),
+    invoiceAction: v.union(
+      v.literal("none"),
+      v.literal("updated_open_invoice"),
+      v.literal("supplemental_invoice_created"),
+      v.literal("manual_credit_required"),
+    ),
+    supplementalInvoiceId: v.optional(v.id("invoices")),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    adjustmentId: Id<"appointmentAdjustments">;
+    invoiceAction:
+      | "none"
+      | "updated_open_invoice"
+      | "supplemental_invoice_created"
+      | "manual_credit_required";
+    supplementalInvoiceId?: Id<"invoices">;
+  }> => {
+    await requireAdmin(ctx);
+    const actorId = await getUserIdFromIdentity(ctx);
+    if (!actorId) throw new Error("Not authenticated");
+    const reason = args.reason.trim();
+    if (reason.length < 3) {
+      throw new Error("A short reason is required for work adjustments.");
+    }
+
+    const appointment = await ctx.db.get(args.appointmentId);
+    if (!appointment) throw new Error("Appointment not found");
+    if (!["confirmed", "in_progress"].includes(appointment.status)) {
+      throw new Error("Only confirmed or in-progress appointments can be adjusted.");
+    }
+
+    const oldPetFeeVehicleIds = appointment.petFeeVehicleIds ?? [];
+    const oldPricing = await buildAdjustmentPricing(
+      ctx,
+      appointment.vehicleIds,
+      appointment.serviceIds,
+      oldPetFeeVehicleIds,
+    );
+    const newPetFeeVehicleIds = args.petFeeVehicleIds ?? [];
+    const newPricing = await buildAdjustmentPricing(
+      ctx,
+      args.vehicleIds,
+      args.serviceIds,
+      newPetFeeVehicleIds,
+    );
+    const priceDelta = Math.round((newPricing.totalPrice - appointment.totalPrice) * 100) / 100;
+    const durationDelta = newPricing.duration - appointment.duration;
+
+    const availability = await ctx.runQuery(api.availability.checkAvailability, {
+      date: appointment.scheduledDate,
+      startTime: appointment.scheduledTime,
+      duration: newPricing.duration,
+      ignoreAppointmentId: args.appointmentId,
+    });
+    if (!availability.available) {
+      throw new ConvexError({
+        code: "TIME_SLOT_UNAVAILABLE",
+        message: availability.reason || "Adjusted work no longer fits this time slot.",
+      });
+    }
+
+    const invoice = await ctx.db
+      .query("invoices")
+      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
+      .first();
+    let invoiceAction:
+      | "none"
+      | "updated_open_invoice"
+      | "supplemental_invoice_created"
+      | "manual_credit_required" = "none";
+    let supplementalInvoiceId: Id<"invoices"> | undefined;
+
+    if (invoice?.status === "paid") {
+      if (priceDelta < 0) {
+        throw new Error(
+          "This adjustment lowers a paid invoice. Create an explicit refund or credit before changing the work.",
+        );
+      }
+      if (priceDelta > 0) {
+        const invoiceCount = (
+          await ctx.runQuery(internal.invoices.getCountInternal, {})
+        ).count;
+        const invoiceNumber = `INV-${String(invoiceCount + 1).padStart(4, "0")}`;
+        const dueDate = new Date();
+        dueDate.setDate(dueDate.getDate() + 30);
+        supplementalInvoiceId = await ctx.db.insert("invoices", {
+          appointmentId: args.appointmentId,
+          userId: appointment.userId,
+          invoiceNumber,
+          items: [
+            {
+              serviceName: `Supplemental work adjustment - ${reason}`,
+              quantity: 1,
+              unitPrice: priceDelta,
+              totalPrice: priceDelta,
+            },
+          ],
+          subtotal: priceDelta,
+          tax: 0,
+          total: priceDelta,
+          status: "draft",
+          dueDate: dueDate.toISOString().split("T")[0],
+          notes: `Supplemental invoice for ${invoice.invoiceNumber}: ${reason}`,
+          depositAmount: 0,
+          depositPaid: true,
+          remainingBalance: priceDelta,
+          paymentOption: "deposit",
+          remainingBalanceCollectionMethod:
+            invoice.remainingBalanceCollectionMethod ?? "send_invoice",
+        });
+        invoiceAction = "supplemental_invoice_created";
+        await ctx.scheduler.runAfter(
+          0,
+          internal.payments.createStripeInvoiceAfterDeposit,
+          {
+            appointmentId: args.appointmentId,
+            invoiceId: supplementalInvoiceId,
+          },
+        );
+      }
+    } else if (invoice) {
+      const subtotal = newPricing.items.reduce(
+        (sum, item) => sum + item.totalPrice,
+        0,
+      );
+      const total = subtotal + invoice.tax;
+      const depositAmount = invoice.depositAmount || 0;
+      await ctx.db.patch(invoice._id, {
+        items: newPricing.items,
+        subtotal,
+        total,
+        remainingBalance: Math.max(0, total - depositAmount),
+        stripeInvoiceId: undefined,
+        stripeInvoiceUrl: undefined,
+        finalPaymentIntentId: undefined,
+        status: invoice.depositPaid ? "draft" : invoice.status,
+        invoiceGenerationError: undefined,
+      });
+      invoiceAction = "updated_open_invoice";
+      if (invoice.depositPaid && (invoice.paymentOption ?? "deposit") === "deposit") {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.payments.createStripeInvoiceAfterDeposit,
+          {
+            appointmentId: args.appointmentId,
+            invoiceId: invoice._id,
+          },
+        );
+      }
+    }
+
+    await ctx.db.patch(args.appointmentId, {
+      vehicleIds: args.vehicleIds,
+      serviceIds: args.serviceIds,
+      petFeeVehicleIds: newPetFeeVehicleIds,
+      duration: newPricing.duration,
+      totalPrice: newPricing.totalPrice,
+    });
+
+    const adjustmentId = await ctx.db.insert("appointmentAdjustments", {
+      appointmentId: args.appointmentId,
+      actorId,
+      reason,
+      oldVehicleIds: appointment.vehicleIds,
+      newVehicleIds: args.vehicleIds,
+      oldServiceIds: appointment.serviceIds,
+      newServiceIds: args.serviceIds,
+      oldPetFeeVehicleIds,
+      newPetFeeVehicleIds,
+      oldItems: oldPricing.items,
+      newItems: newPricing.items,
+      priceDelta,
+      durationDelta,
+      invoiceAction,
+      invoiceId: invoice?._id,
+      supplementalInvoiceId,
+      createdAt: Date.now(),
+    });
+
+    return {
+      adjustmentId,
+      invoiceAction,
+      supplementalInvoiceId,
+    };
+  },
+});
+
 // Delete an appointment
 export const deleteAppointment = mutation({
   args: { appointmentId: v.id("appointments") },
@@ -993,14 +1327,14 @@ export const deleteAppointment = mutation({
     const userId = await getUserIdFromIdentity(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    const invoice = await ctx.db
+    const invoices = await ctx.db
       .query("invoices")
       .withIndex("by_appointment", (q) =>
         q.eq("appointmentId", args.appointmentId),
       )
-      .unique();
+      .collect();
 
-    if (invoice && invoice.status !== "paid") {
+    for (const invoice of invoices.filter((item) => item.status !== "paid")) {
       await ctx.db.delete(invoice._id);
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -287,6 +287,69 @@ const schema = defineSchema({
     .index("by_date", ["scheduledDate"])
     .index("by_status", ["status"]),
 
+  appointmentAdjustments: defineTable({
+    appointmentId: v.id("appointments"),
+    actorId: v.id("users"),
+    reason: v.string(),
+    oldVehicleIds: v.array(v.id("vehicles")),
+    newVehicleIds: v.array(v.id("vehicles")),
+    oldServiceIds: v.array(v.id("services")),
+    newServiceIds: v.array(v.id("services")),
+    oldPetFeeVehicleIds: v.array(v.id("vehicles")),
+    newPetFeeVehicleIds: v.array(v.id("vehicles")),
+    oldItems: v.array(
+      v.object({
+        itemType: v.optional(
+          v.union(
+            v.literal("service"),
+            v.literal("pet_fee"),
+            v.literal("travel_fee"),
+          ),
+        ),
+        serviceId: v.optional(v.id("services")),
+        vehicleId: v.optional(v.id("vehicles")),
+        vehicleLabel: v.optional(v.string()),
+        vehicleTypeId: v.optional(v.id("vehicleTypes")),
+        serviceName: v.string(),
+        quantity: v.number(),
+        unitPrice: v.number(),
+        totalPrice: v.number(),
+      }),
+    ),
+    newItems: v.array(
+      v.object({
+        itemType: v.optional(
+          v.union(
+            v.literal("service"),
+            v.literal("pet_fee"),
+            v.literal("travel_fee"),
+          ),
+        ),
+        serviceId: v.optional(v.id("services")),
+        vehicleId: v.optional(v.id("vehicles")),
+        vehicleLabel: v.optional(v.string()),
+        vehicleTypeId: v.optional(v.id("vehicleTypes")),
+        serviceName: v.string(),
+        quantity: v.number(),
+        unitPrice: v.number(),
+        totalPrice: v.number(),
+      }),
+    ),
+    priceDelta: v.number(),
+    durationDelta: v.number(),
+    invoiceAction: v.union(
+      v.literal("none"),
+      v.literal("updated_open_invoice"),
+      v.literal("supplemental_invoice_created"),
+      v.literal("manual_credit_required"),
+    ),
+    invoiceId: v.optional(v.id("invoices")),
+    supplementalInvoiceId: v.optional(v.id("invoices")),
+    createdAt: v.number(),
+  })
+    .index("by_appointment", ["appointmentId"])
+    .index("by_actor", ["actorId"]),
+
   bookingDrafts: defineTable({
     sourceUserId: v.optional(v.id("users")),
     customerName: v.string(),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1289,13 +1289,13 @@ export const deleteUser = mutation({
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .collect();
     for (const appointment of appointments) {
-      const invoice = await ctx.db
+      const invoices = await ctx.db
         .query("invoices")
         .withIndex("by_appointment", (q) =>
           q.eq("appointmentId", appointment._id),
         )
-        .unique();
-      if (invoice && invoice.status !== "paid") {
+        .collect();
+      for (const invoice of invoices.filter((item) => item.status !== "paid")) {
         await ctx.db.delete(invoice._id);
       }
       await ctx.db.delete(appointment._id);


### PR DESCRIPTION
## Summary

Adds an explicit admin Adjust Work flow for confirmed and in-progress appointments, including service changes, pet hair fees, saved vehicle additions/removals, duration recalculation, audit snapshots, and safe invoice handling.

## Implementation Notes

- Adds appointment adjustment audit records with old/new items, price delta, duration delta, actor, reason, and invoice action.
- Updates unpaid/open invoices in place and clears stale Stripe invoice linkage for safe reissue.
- Keeps paid invoices immutable; positive deltas create supplemental invoices, while negative deltas are blocked for an explicit refund/credit workflow.
- Adds admin appointment detail UI for previewing/applying work adjustments and viewing adjustment history.
- Adds local query result typings where Next build surfaced existing strict TypeScript gaps.

## Testing Notes

- pnpm lint
- pnpm test:once
- pnpm build

Closes #35