### PR TITLE
fix: improve travel fee settings tiers

### DIFF
--- a/components/admin/services-client.tsx
+++ b/components/admin/services-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ColumnDef } from "@tanstack/react-table";
 import { useAction, useMutation, useQuery } from "convex/react";
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
 import {
   Dialog,
   DialogContent,
@@ -33,14 +34,21 @@ import { toast } from "sonner";
 import {
   AlertCircle,
   ArrowUpDown,
+  CheckCircle2,
+  Clock,
   Edit,
+  MapPin,
   MoreHorizontal,
   Plus,
+  Route,
   Save,
   Trash2,
   X,
 } from "lucide-react";
 import { DEFAULT_PET_FEE_TIME_MINUTES } from "@/convex/lib/booking";
+import RadarAddressField, {
+  type RadarLocationValue,
+} from "@/components/ui/radar-address-field";
 
 type ServiceRecord = {
   _id: Id<"services">;
@@ -101,8 +109,14 @@ export default function ServicesClient() {
     isActive: true,
   });
   const travelFeeSettings = useQuery(api.travelFeeSettings.get);
-  const updateTravelFeeSettings = useAction(api.travelFeeSettings.validateOriginAndUpsert);
+  const validateTravelFeeOrigin = useAction(
+    api.travelFeeSettings.validateOriginAndUpsert,
+  );
+  const updateTravelFeeRules = useMutation(api.travelFeeSettings.updateRules);
   const [isEditingTravelFee, setIsEditingTravelFee] = useState(false);
+  const [isReplacingTravelOrigin, setIsReplacingTravelOrigin] = useState(false);
+  const [pendingTravelOrigin, setPendingTravelOrigin] =
+    useState<RadarLocationValue | null>(null);
   const [travelFeeValues, setTravelFeeValues] = useState({
     originStreet: "220 N. Tyler St",
     originCity: "Little Rock",
@@ -110,10 +124,10 @@ export default function ServicesClient() {
     originZip: "72205",
     originLatitude: 34.752258,
     originLongitude: -92.329768,
-    freeRadiusMiles: 25,
+    freeRadiusMiles: 20,
     midRangeMaxMiles: 35,
     longRangeMaxMiles: 50,
-    midRangeFee: 30,
+    midRangeFee: 25,
     longRangeFee: 50,
     perMileRateAfterLongRange: 2,
     midRangeBufferMinutes: 30,
@@ -142,6 +156,72 @@ export default function ServicesClient() {
       setTravelFeeValues(travelFeeSettings);
     }
   }, [travelFeeSettings]);
+
+  const travelFeeValidationMessage = useMemo(() => {
+    const requiredNumbers = [
+      travelFeeValues.freeRadiusMiles,
+      travelFeeValues.midRangeMaxMiles,
+      travelFeeValues.longRangeMaxMiles,
+      travelFeeValues.midRangeFee,
+      travelFeeValues.longRangeFee,
+      travelFeeValues.perMileRateAfterLongRange,
+      travelFeeValues.midRangeBufferMinutes,
+      travelFeeValues.longRangeBufferMinutes,
+    ];
+
+    if (requiredNumbers.some((value) => !Number.isFinite(value) || value < 0)) {
+      return "All mile, fee, and travel-time values must be zero or greater.";
+    }
+    if (travelFeeValues.midRangeMaxMiles < travelFeeValues.freeRadiusMiles + 1) {
+      return "Tier 1 must end at least 1 mile after the free service cutoff.";
+    }
+    if (
+      travelFeeValues.longRangeMaxMiles <
+      travelFeeValues.midRangeMaxMiles + 1
+    ) {
+      return "Tier 2 must end at least 1 mile after Tier 1.";
+    }
+    return "";
+  }, [travelFeeValues]);
+
+  const updateTravelNumber = (
+    key:
+      | "freeRadiusMiles"
+      | "midRangeMaxMiles"
+      | "longRangeMaxMiles"
+      | "midRangeFee"
+      | "longRangeFee"
+      | "perMileRateAfterLongRange"
+      | "midRangeBufferMinutes"
+      | "longRangeBufferMinutes",
+    value: number,
+  ) => {
+    setTravelFeeValues((current) => {
+      const next = { ...current, [key]: Number.isFinite(value) ? value : 0 };
+      if (
+        key === "freeRadiusMiles" &&
+        next.midRangeMaxMiles < next.freeRadiusMiles + 1
+      ) {
+        next.midRangeMaxMiles = next.freeRadiusMiles + 1;
+      }
+      if (
+        (key === "freeRadiusMiles" || key === "midRangeMaxMiles") &&
+        next.longRangeMaxMiles < next.midRangeMaxMiles + 1
+      ) {
+        next.longRangeMaxMiles = next.midRangeMaxMiles + 1;
+      }
+      return next;
+    });
+  };
+
+  const resetTravelFeeEditing = () => {
+    setIsEditingTravelFee(false);
+    setIsReplacingTravelOrigin(false);
+    setPendingTravelOrigin(null);
+    if (travelFeeSettings) {
+      setTravelFeeValues(travelFeeSettings);
+    }
+  };
 
   if (servicesQuery === undefined) {
     return (
@@ -237,13 +317,101 @@ export default function ServicesClient() {
   const formatTravelFeePricing = () => {
     const settings = travelFeeSettings ?? travelFeeValues;
     if (!settings.isActive) return "Travel fees off";
-    return `Travel: <${
+    return `Travel: 0-${
       settings.freeRadiusMiles
-    } mi free • $${settings.midRangeFee.toFixed(0)} to ${
+    } mi free • ${settings.freeRadiusMiles + 1}-${
       settings.midRangeMaxMiles
-    } mi • $${settings.longRangeFee.toFixed(0)} to ${
+    } mi $${settings.midRangeFee.toFixed(0)} • ${
+      settings.midRangeMaxMiles + 1
+    }-${
       settings.longRangeMaxMiles
-    } mi • $${settings.perMileRateAfterLongRange.toFixed(2)}/mi after`;
+    } mi $${settings.longRangeFee.toFixed(0)} • $${settings.perMileRateAfterLongRange.toFixed(2)}/mi after`;
+  };
+
+  const travelOriginLabel = [
+    travelFeeValues.originStreet,
+    travelFeeValues.originCity,
+    travelFeeValues.originState,
+    travelFeeValues.originZip,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  const pendingOriginParts = () => {
+    const addressLabel = pendingTravelOrigin?.addressLabel ?? "";
+    return {
+      originStreet:
+        pendingTravelOrigin?.street || addressLabel.split(",")[0]?.trim() || "",
+      originCity: pendingTravelOrigin?.city || "",
+      originState: pendingTravelOrigin?.state || "",
+      originZip: pendingTravelOrigin?.postalCode || "",
+    };
+  };
+
+  const travelRulePayload = {
+    freeRadiusMiles: travelFeeValues.freeRadiusMiles,
+    midRangeMaxMiles: travelFeeValues.midRangeMaxMiles,
+    longRangeMaxMiles: travelFeeValues.longRangeMaxMiles,
+    midRangeFee: travelFeeValues.midRangeFee,
+    longRangeFee: travelFeeValues.longRangeFee,
+    perMileRateAfterLongRange: travelFeeValues.perMileRateAfterLongRange,
+    midRangeBufferMinutes: travelFeeValues.midRangeBufferMinutes,
+    longRangeBufferMinutes: travelFeeValues.longRangeBufferMinutes,
+    isActive: travelFeeValues.isActive,
+  };
+
+  const saveTravelFeeRules = async () => {
+    if (travelFeeValidationMessage) {
+      toast.error(travelFeeValidationMessage);
+      return;
+    }
+
+    try {
+      await updateTravelFeeRules(travelRulePayload);
+      setIsEditingTravelFee(false);
+      setIsReplacingTravelOrigin(false);
+      setPendingTravelOrigin(null);
+      toast.success("Travel fee settings updated");
+      router.refresh();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to update travel fee settings";
+      toast.error(message);
+    }
+  };
+
+  const saveTravelOrigin = async () => {
+    if (travelFeeValidationMessage) {
+      toast.error(travelFeeValidationMessage);
+      return;
+    }
+
+    const origin = pendingOriginParts();
+    if (
+      !pendingTravelOrigin ||
+      !origin.originStreet ||
+      !origin.originCity ||
+      !origin.originState ||
+      !origin.originZip
+    ) {
+      toast.error("Select a validated origin address before saving.");
+      return;
+    }
+
+    try {
+      await validateTravelFeeOrigin({
+        ...origin,
+        ...travelRulePayload,
+      });
+      setIsReplacingTravelOrigin(false);
+      setPendingTravelOrigin(null);
+      toast.success("Travel origin validated and saved");
+      router.refresh();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to validate travel origin";
+      toast.error(message);
+    }
   };
 
   const popularityBadgeClass = (popularity?: string) => {
@@ -583,104 +751,339 @@ export default function ServicesClient() {
             </div>
           )}
           {isEditingTravelFee ? (
-            <div className="flex flex-wrap items-end gap-2 rounded-md border p-2">
-              <div className="flex items-center gap-2 pb-2">
-                <Switch
-                  checked={travelFeeValues.isActive}
-                  onCheckedChange={(checked) =>
-                    setTravelFeeValues((current) => ({ ...current, isActive: checked }))
-                  }
-                />
-                <span className="text-sm text-muted-foreground">Travel fee</span>
+            <div className="w-full space-y-4 rounded-md border bg-background p-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      checked={travelFeeValues.isActive}
+                      onCheckedChange={(checked) =>
+                        setTravelFeeValues((current) => ({
+                          ...current,
+                          isActive: checked,
+                        }))
+                      }
+                    />
+                    <h3 className="text-sm font-semibold">Travel fee rules</h3>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {formatTravelFeePricing()}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    onClick={saveTravelFeeRules}
+                    disabled={Boolean(travelFeeValidationMessage)}
+                  >
+                    <Save className="h-4 w-4" />
+                    Save rules
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={resetTravelFeeEditing}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
-              {[
-                ["originStreet", "Origin street"],
-                ["originCity", "Origin city"],
-                ["originState", "State"],
-                ["originZip", "ZIP"],
-              ].map(([key, label]) => (
-                <div key={key} className="space-y-1">
-                  <Label className="text-xs">{label}</Label>
-                  <Input
-                    value={travelFeeValues[key as keyof typeof travelFeeValues] as string}
-                    onChange={(event) =>
-                      setTravelFeeValues((current) => ({
-                        ...current,
-                        [key]: event.target.value,
-                      }))
-                    }
-                    className={key === "originStreet" ? "w-44" : "w-24"}
-                  />
+
+              <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+                <div className="rounded-md border p-3">
+                  <div className="flex items-start gap-2">
+                    <MapPin className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <div>
+                        <p className="text-sm font-medium">Validated service origin</p>
+                        <p className="break-words text-sm text-muted-foreground">
+                          {travelOriginLabel}
+                        </p>
+                      </div>
+                      <Badge variant="secondary" className="gap-1">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Coordinates saved
+                      </Badge>
+                      {isReplacingTravelOrigin ? (
+                        <div className="space-y-3 pt-1">
+                          <RadarAddressField
+                            label="New origin address"
+                            placeholder="Search for the new starting point"
+                            value={pendingTravelOrigin}
+                            onSelect={setPendingTravelOrigin}
+                          />
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              size="sm"
+                              onClick={saveTravelOrigin}
+                              disabled={!pendingTravelOrigin}
+                            >
+                              <Save className="h-4 w-4" />
+                              Validate origin
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => {
+                                setIsReplacingTravelOrigin(false);
+                                setPendingTravelOrigin(null);
+                              }}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setIsReplacingTravelOrigin(true)}
+                        >
+                          Replace origin
+                        </Button>
+                      )}
+                    </div>
+                  </div>
                 </div>
-              ))}
-              {[
-                ["freeRadiusMiles", "Free under mi", "1"],
-                ["midRangeMaxMiles", "Mid max mi", "1"],
-                ["longRangeMaxMiles", "Long max mi", "1"],
-                ["midRangeFee", "Mid fee", "0.01"],
-                ["longRangeFee", "Long fee", "0.01"],
-                ["perMileRateAfterLongRange", "After long $/mi", "0.01"],
-                ["midRangeBufferMinutes", "Mid min", "5"],
-                ["longRangeBufferMinutes", "Long min", "5"],
-              ].map(([key, label, step]) => (
-                <div key={key} className="space-y-1">
-                  <Label className="text-xs">{label}</Label>
-                  <Input
-                    type="number"
-                    step={step}
-                    value={travelFeeValues[key as keyof typeof travelFeeValues] as number}
-                    onChange={(event) =>
-                      setTravelFeeValues((current) => ({
-                        ...current,
-                        [key]: parseFloat(event.target.value) || 0,
-                      }))
-                    }
-                    className="w-24"
-                  />
+
+                <div className="rounded-md border p-3">
+                  <div className="flex items-start gap-2">
+                    <Route className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                    <div className="min-w-0 flex-1 space-y-4">
+                      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem] sm:items-end">
+                        <div>
+                          <p className="text-sm font-medium">Default service cutoff</p>
+                          <p className="text-xs text-muted-foreground">
+                            0-{travelFeeValues.freeRadiusMiles} miles has no travel fee.
+                            Tier 1 starts at {travelFeeValues.freeRadiusMiles + 1} miles.
+                          </p>
+                        </div>
+                        <div className="space-y-1">
+                          <Label className="text-xs">Free through mi</Label>
+                          <Input
+                            type="number"
+                            min="0"
+                            step="1"
+                            value={travelFeeValues.freeRadiusMiles}
+                            onChange={(event) =>
+                              updateTravelNumber(
+                                "freeRadiusMiles",
+                                Math.floor(Number.parseFloat(event.target.value) || 0),
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                          <span>{travelFeeValues.freeRadiusMiles + 1} mi</span>
+                          <span>{travelFeeValues.midRangeMaxMiles} mi</span>
+                          <span>{travelFeeValues.longRangeMaxMiles} mi</span>
+                        </div>
+                        <Slider
+                          min={travelFeeValues.freeRadiusMiles + 1}
+                          max={Math.max(75, travelFeeValues.longRangeMaxMiles + 10)}
+                          step={1}
+                          minStepsBetweenThumbs={1}
+                          value={[
+                            travelFeeValues.midRangeMaxMiles,
+                            travelFeeValues.longRangeMaxMiles,
+                          ]}
+                          onValueChange={(value) => {
+                            const mid = Math.max(
+                              travelFeeValues.freeRadiusMiles + 1,
+                              Math.round(value[0] ?? travelFeeValues.midRangeMaxMiles),
+                            );
+                            const long = Math.max(
+                              mid + 1,
+                              Math.round(value[1] ?? travelFeeValues.longRangeMaxMiles),
+                            );
+                            setTravelFeeValues((current) => ({
+                              ...current,
+                              midRangeMaxMiles: mid,
+                              longRangeMaxMiles: long,
+                            }));
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </div>
-              ))}
-              <Button
-                size="sm"
-                onClick={async () => {
-                  try {
-                    await updateTravelFeeSettings({
-                      originStreet: travelFeeValues.originStreet,
-                      originCity: travelFeeValues.originCity,
-                      originState: travelFeeValues.originState,
-                      originZip: travelFeeValues.originZip,
-                      freeRadiusMiles: travelFeeValues.freeRadiusMiles,
-                      midRangeMaxMiles: travelFeeValues.midRangeMaxMiles,
-                      longRangeMaxMiles: travelFeeValues.longRangeMaxMiles,
-                      midRangeFee: travelFeeValues.midRangeFee,
-                      longRangeFee: travelFeeValues.longRangeFee,
-                      perMileRateAfterLongRange:
-                        travelFeeValues.perMileRateAfterLongRange,
-                      midRangeBufferMinutes: travelFeeValues.midRangeBufferMinutes,
-                      longRangeBufferMinutes: travelFeeValues.longRangeBufferMinutes,
-                      isActive: travelFeeValues.isActive,
-                    });
-                    setIsEditingTravelFee(false);
-                    toast.success("Travel fee settings updated");
-                    router.refresh();
-                  } catch {
-                    toast.error("Failed to update travel fee settings");
-                  }
-                }}
-              >
-                <Save className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => {
-                  setIsEditingTravelFee(false);
-                  if (travelFeeSettings) {
-                    setTravelFeeValues(travelFeeSettings);
-                  }
-                }}
-              >
-                <X className="h-4 w-4" />
-              </Button>
+              </div>
+
+              <div className="grid gap-3 lg:grid-cols-3">
+                <div className="rounded-md border p-3">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium">Tier 1</p>
+                      <p className="text-xs text-muted-foreground">
+                        {travelFeeValues.freeRadiusMiles + 1}-
+                        {travelFeeValues.midRangeMaxMiles} miles
+                      </p>
+                    </div>
+                    <Badge variant="secondary">
+                      +{travelFeeValues.midRangeBufferMinutes} min
+                    </Badge>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Ends mi</Label>
+                      <Input
+                        type="number"
+                        min={travelFeeValues.freeRadiusMiles + 1}
+                        step="1"
+                        value={travelFeeValues.midRangeMaxMiles}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "midRangeMaxMiles",
+                            Math.floor(Number.parseFloat(event.target.value) || 0),
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Fee</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={travelFeeValues.midRangeFee}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "midRangeFee",
+                            Number.parseFloat(event.target.value) || 0,
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Min</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="5"
+                        value={travelFeeValues.midRangeBufferMinutes}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "midRangeBufferMinutes",
+                            Math.floor(Number.parseFloat(event.target.value) || 0),
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-md border p-3">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium">Tier 2</p>
+                      <p className="text-xs text-muted-foreground">
+                        {travelFeeValues.midRangeMaxMiles + 1}-
+                        {travelFeeValues.longRangeMaxMiles} miles
+                      </p>
+                    </div>
+                    <Badge variant="secondary">
+                      +{travelFeeValues.longRangeBufferMinutes} min
+                    </Badge>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Ends mi</Label>
+                      <Input
+                        type="number"
+                        min={travelFeeValues.midRangeMaxMiles + 1}
+                        step="1"
+                        value={travelFeeValues.longRangeMaxMiles}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "longRangeMaxMiles",
+                            Math.floor(Number.parseFloat(event.target.value) || 0),
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Fee</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={travelFeeValues.longRangeFee}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "longRangeFee",
+                            Number.parseFloat(event.target.value) || 0,
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Min</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="5"
+                        value={travelFeeValues.longRangeBufferMinutes}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "longRangeBufferMinutes",
+                            Math.floor(Number.parseFloat(event.target.value) || 0),
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-md border p-3">
+                  <div className="mb-3 flex items-start gap-2">
+                    <Clock className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                    <div>
+                      <p className="text-sm font-medium">Over Tier 2</p>
+                      <p className="text-xs text-muted-foreground">
+                        After {travelFeeValues.longRangeMaxMiles} miles, charge Tier 2
+                        plus a per-mile rate.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Base fee</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={travelFeeValues.longRangeFee}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "longRangeFee",
+                            Number.parseFloat(event.target.value) || 0,
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">$/mi after</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={travelFeeValues.perMileRateAfterLongRange}
+                        onChange={(event) =>
+                          updateTravelNumber(
+                            "perMileRateAfterLongRange",
+                            Number.parseFloat(event.target.value) || 0,
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {travelFeeValidationMessage && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {travelFeeValidationMessage}
+                </div>
+              )}
             </div>
           ) : (
             <div className="flex items-center gap-2">

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { cn } from "@/lib/utils";
+
+function Slider({
+  className,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      className={cn(
+        "relative flex w-full touch-none select-none items-center data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="absolute h-full bg-primary"
+        />
+      </SliderPrimitive.Track>
+      {props.value?.map((_, index) => (
+        <SliderPrimitive.Thumb
+          key={index}
+          data-slot="slider-thumb"
+          className="block h-5 w-5 rounded-full border-2 border-primary bg-background shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/convex/lib/travelFees.ts
+++ b/convex/lib/travelFees.ts
@@ -43,10 +43,10 @@ export const defaultTravelFeeSettings: TravelFeeSettings = {
   originZip: "72205",
   originLatitude: 34.752258,
   originLongitude: -92.329768,
-  freeRadiusMiles: 25,
+  freeRadiusMiles: 20,
   midRangeMaxMiles: 35,
   longRangeMaxMiles: 50,
-  midRangeFee: 30,
+  midRangeFee: 25,
   longRangeFee: 50,
   perMileRateAfterLongRange: 2,
   midRangeBufferMinutes: 30,
@@ -79,11 +79,11 @@ export function normalizeTravelFeeSettings(
     defaultTravelFeeSettings.freeRadiusMiles,
   );
   const midRangeMaxMiles = Math.max(
-    freeRadiusMiles,
+    freeRadiusMiles + 1,
     cleanNumber(settings.midRangeMaxMiles, defaultTravelFeeSettings.midRangeMaxMiles),
   );
   const longRangeMaxMiles = Math.max(
-    midRangeMaxMiles,
+    midRangeMaxMiles + 1,
     cleanNumber(settings.longRangeMaxMiles, defaultTravelFeeSettings.longRangeMaxMiles),
   );
 
@@ -155,7 +155,7 @@ export function calculateTravelFeeForMiles(
 ) {
   const settings = normalizeTravelFeeSettings(settingsInput);
   if (!settings.isActive) return 0;
-  if (distanceMiles < settings.freeRadiusMiles) return 0;
+  if (distanceMiles <= settings.freeRadiusMiles) return 0;
   if (distanceMiles <= settings.midRangeMaxMiles) return settings.midRangeFee;
   if (distanceMiles <= settings.longRangeMaxMiles) return settings.longRangeFee;
   const fee =
@@ -171,7 +171,7 @@ export function calculateTravelBufferMinutesForMiles(
 ) {
   const settings = normalizeTravelFeeSettings(settingsInput);
   if (!settings.isActive) return 0;
-  if (distanceMiles < settings.freeRadiusMiles) return 0;
+  if (distanceMiles <= settings.freeRadiusMiles) return 0;
   if (distanceMiles <= settings.midRangeMaxMiles) {
     return settings.midRangeBufferMinutes;
   }

--- a/convex/travelFeeSettings.ts
+++ b/convex/travelFeeSettings.ts
@@ -32,11 +32,72 @@ const travelFeeSettingsArgs = {
   isActive: v.boolean(),
 };
 
+const travelFeeRuleArgs = {
+  freeRadiusMiles: v.number(),
+  midRangeMaxMiles: v.number(),
+  longRangeMaxMiles: v.number(),
+  midRangeFee: v.number(),
+  longRangeFee: v.number(),
+  perMileRateAfterLongRange: v.number(),
+  midRangeBufferMinutes: v.number(),
+  longRangeBufferMinutes: v.number(),
+  isActive: v.boolean(),
+};
+
 const travelFeeSettingsWithOriginArgs = {
   ...travelFeeSettingsArgs,
   originLatitude: v.number(),
   originLongitude: v.number(),
 };
+
+type TravelFeeRuleValues = Pick<
+  TravelFeeSettings,
+  | "freeRadiusMiles"
+  | "midRangeMaxMiles"
+  | "longRangeMaxMiles"
+  | "midRangeFee"
+  | "longRangeFee"
+  | "perMileRateAfterLongRange"
+  | "midRangeBufferMinutes"
+  | "longRangeBufferMinutes"
+>;
+
+function assertValidTravelFeeRules(settings: TravelFeeRuleValues) {
+  const numericFields: Array<[keyof TravelFeeRuleValues, string]> = [
+    ["freeRadiusMiles", "Default service cutoff"],
+    ["midRangeMaxMiles", "Tier 1 max miles"],
+    ["longRangeMaxMiles", "Tier 2 max miles"],
+    ["midRangeFee", "Tier 1 fee"],
+    ["longRangeFee", "Tier 2 fee"],
+    ["perMileRateAfterLongRange", "Overage per-mile rate"],
+    ["midRangeBufferMinutes", "Tier 1 travel time"],
+    ["longRangeBufferMinutes", "Tier 2 travel time"],
+  ];
+
+  for (const [field, label] of numericFields) {
+    const value = settings[field];
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      throw new ConvexError({
+        code: "INVALID_TRAVEL_FEE_SETTINGS",
+        message: `${label} must be zero or greater.`,
+      });
+    }
+  }
+
+  if (settings.midRangeMaxMiles < settings.freeRadiusMiles + 1) {
+    throw new ConvexError({
+      code: "INVALID_TRAVEL_FEE_SETTINGS",
+      message: "Tier 1 must end at least 1 mile after the free service cutoff.",
+    });
+  }
+
+  if (settings.longRangeMaxMiles < settings.midRangeMaxMiles + 1) {
+    throw new ConvexError({
+      code: "INVALID_TRAVEL_FEE_SETTINGS",
+      message: "Tier 2 must end at least 1 mile after Tier 1.",
+    });
+  }
+}
 
 async function geocodeOriginAddress(args: {
   originStreet: string;
@@ -111,7 +172,30 @@ export const upsert = mutation({
     await requireAdmin(ctx);
 
     const existing = await ctx.db.query("travelFeeSettings").first();
+    assertValidTravelFeeRules(args);
     const settings = normalizeTravelFeeSettings(args);
+
+    if (existing) {
+      await ctx.db.patch(existing._id, settings);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("travelFeeSettings", settings);
+  },
+});
+
+export const updateRules = mutation({
+  args: travelFeeRuleArgs,
+  returns: v.id("travelFeeSettings"),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const existing = await ctx.db.query("travelFeeSettings").first();
+    assertValidTravelFeeRules(args);
+    const current = normalizeTravelFeeSettings(
+      existing ?? defaultTravelFeeSettings,
+    );
+    const settings = normalizeTravelFeeSettings({ ...current, ...args });
 
     if (existing) {
       await ctx.db.patch(existing._id, settings);
@@ -144,6 +228,7 @@ export const validateOriginAndUpsert = action({
   handler: async (ctx, args): Promise<Id<"travelFeeSettings">> => {
     await requireAdmin(ctx);
 
+    assertValidTravelFeeRules(args);
     const normalized = normalizeTravelFeeSettings(args);
     const coords = await geocodeOriginAddress(normalized);
     const settings: TravelFeeSettings = {

--- a/convex/travelFees.test.ts
+++ b/convex/travelFees.test.ts
@@ -15,9 +15,9 @@ describe("travelFees", () => {
   });
 
   test("uses tiered fees for estimated travel distance", () => {
-    expect(calculateTravelFeeForMiles(24.9)).toBe(0);
-    expect(calculateTravelFeeForMiles(25)).toBe(30);
-    expect(calculateTravelFeeForMiles(35)).toBe(30);
+    expect(calculateTravelFeeForMiles(20)).toBe(0);
+    expect(calculateTravelFeeForMiles(20.1)).toBe(25);
+    expect(calculateTravelFeeForMiles(35)).toBe(25);
     expect(calculateTravelFeeForMiles(35.1)).toBe(50);
     expect(calculateTravelFeeForMiles(50)).toBe(50);
     expect(calculateTravelFeeForMiles(50.1)).toBe(50.2);
@@ -83,10 +83,10 @@ describe("travelFees", () => {
       originZip: "72701",
       originLatitude: 36.06258,
       originLongitude: -94.15743,
-      freeRadiusMiles: 25,
+      freeRadiusMiles: 20,
       midRangeMaxMiles: 35,
       longRangeMaxMiles: 50,
-      midRangeFee: 30,
+      midRangeFee: 25,
       longRangeFee: 50,
       perMileRateAfterLongRange: 2,
       midRangeBufferMinutes: 30,
@@ -143,10 +143,10 @@ describe("travelFees", () => {
       originCity: "Fayetteville",
       originState: "AR",
       originZip: "72701",
-      freeRadiusMiles: 25,
+      freeRadiusMiles: 20,
       midRangeMaxMiles: 35,
       longRangeMaxMiles: 50,
-      midRangeFee: 30,
+      midRangeFee: 25,
       longRangeFee: 50,
       perMileRateAfterLongRange: 2,
       midRangeBufferMinutes: 30,
@@ -161,9 +161,89 @@ describe("travelFees", () => {
     expect(settings.originLongitude).toBe(-94.15743);
   });
 
+  test("updates fee rules without changing the validated origin", async () => {
+    const t = convexTest(schema, modules);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-update-travel-rules@example.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-update-travel-rules@example.com",
+    });
+
+    await asAdmin.mutation(api.travelFeeSettings.upsert, {
+      originStreet: "100 Origin Rd",
+      originCity: "Fayetteville",
+      originState: "AR",
+      originZip: "72701",
+      originLatitude: 36.06258,
+      originLongitude: -94.15743,
+      freeRadiusMiles: 20,
+      midRangeMaxMiles: 35,
+      longRangeMaxMiles: 50,
+      midRangeFee: 25,
+      longRangeFee: 50,
+      perMileRateAfterLongRange: 2,
+      midRangeBufferMinutes: 30,
+      longRangeBufferMinutes: 60,
+      isActive: true,
+    });
+
+    await asAdmin.mutation(api.travelFeeSettings.updateRules, {
+      freeRadiusMiles: 18,
+      midRangeMaxMiles: 32,
+      longRangeMaxMiles: 52,
+      midRangeFee: 25,
+      longRangeFee: 50,
+      perMileRateAfterLongRange: 2,
+      midRangeBufferMinutes: 30,
+      longRangeBufferMinutes: 60,
+      isActive: true,
+    });
+
+    const settings = await t.query(api.travelFeeSettings.get, {});
+    expect(settings.originStreet).toBe("100 Origin Rd");
+    expect(settings.originLatitude).toBe(36.06258);
+    expect(settings.freeRadiusMiles).toBe(18);
+    expect(settings.midRangeFee).toBe(25);
+  });
+
+  test("rejects overlapping travel fee tiers", async () => {
+    const t = convexTest(schema, modules);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-invalid-travel-rules@example.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-invalid-travel-rules@example.com",
+    });
+
+    await expect(
+      asAdmin.mutation(api.travelFeeSettings.updateRules, {
+        freeRadiusMiles: 20,
+        midRangeMaxMiles: 20,
+        longRangeMaxMiles: 50,
+        midRangeFee: 25,
+        longRangeFee: 50,
+        perMileRateAfterLongRange: 2,
+        midRangeBufferMinutes: 30,
+        longRangeBufferMinutes: 60,
+        isActive: true,
+      }),
+    ).rejects.toThrow("Tier 1 must end");
+  });
+
   test("uses travel buffers for appointment blocking", () => {
-    expect(calculateTravelBufferMinutesForMiles(24.9)).toBe(0);
-    expect(calculateTravelBufferMinutesForMiles(25)).toBe(30);
+    expect(calculateTravelBufferMinutesForMiles(20)).toBe(0);
+    expect(calculateTravelBufferMinutesForMiles(20.1)).toBe(30);
     expect(calculateTravelBufferMinutesForMiles(35)).toBe(30);
     expect(calculateTravelBufferMinutesForMiles(35.1)).toBe(60);
     expect(calculateTravelBufferMinutesForMiles(50)).toBe(60);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slider':
+        specifier: ^1.3.6
+        version: 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
@@ -1149,89 +1152,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1359,48 +1378,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@16.1.1':
     resolution: {integrity: sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.0.10':
     resolution: {integrity: sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.0.10':
     resolution: {integrity: sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.0.10':
     resolution: {integrity: sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.0.10':
     resolution: {integrity: sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==}
@@ -2374,56 +2401,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -2739,24 +2777,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2980,41 +3022,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4303,24 +4353,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -9325,7 +9379,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9347,7 +9401,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- Rework the admin travel-fee editor into a clearer origin, cutoff, tier, and overage settings flow.
- Default travel rules now match the admin request: 0-20 miles free, 21-35 miles , 36-50 miles , and  per mile after 50.
- Save fee rules without revalidating the origin; replacing the origin uses Radar validation and keeps the saved coordinates for future calculations.

## Implementation Notes
- Added a shadcn-style range slider component for tier boundaries.
- Added backend validation and a separate updateRules mutation that preserves the validated origin.
- Made the free cutoff inclusive for fee and appointment buffer calculations.

## Testing Notes
- pnpm exec tsc --noEmit
- pnpm test:once convex/travelFees.test.ts convex/payments.test.ts
- pnpm lint
- pnpm test:once
- set -a; source /Users/newrgm/dev/RocktownLabs/clients/rivercitymd/.env.local; set +a; pnpm build

Closes #74