### PR TITLE
fix: repair coupon creation and discount workflow

### DIFF
--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -52,6 +52,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 import { useEffect, useState } from "react";
 import { formatDateStringLong } from "@/lib/time";
+import { normalizeStripeCouponCode } from "@/convex/lib/coupons";
 
 type Props = {
   appointmentId: Id<"appointments">;
@@ -150,7 +151,8 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
 
   const handleApplyDiscount = async () => {
     if (!invoice) return;
-    if (!couponCode.trim()) {
+    const normalizedCouponCode = normalizeStripeCouponCode(couponCode);
+    if (!normalizedCouponCode) {
       toast.error("Please enter a coupon code");
       return;
     }
@@ -163,7 +165,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     try {
       await applyCouponToInvoice({
         invoiceId: invoice._id,
-        couponCode: couponCode.trim().toUpperCase(),
+        couponCode: normalizedCouponCode,
         discountType,
         discountValue: Number(discountValue),
       });
@@ -518,6 +520,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
   const services = typedServices;
   const vehicles = typedVehicles;
   const adjustmentVehicles = customerVehicles.length > 0 ? customerVehicles : vehicles;
+  const normalizedCouponPreview = normalizeStripeCouponCode(couponCode);
   const beforePhotoGroups = Object.entries(
     beforePhotos.reduce<
       Record<string, AppointmentBeforePhoto[]>
@@ -624,6 +627,15 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
           </p>
         </div>
       )}
+      {["confirmed", "in_progress"].includes(data.status) &&
+        invoice &&
+        invoice.status !== "paid" && (
+          <div className="rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-100">
+            Apply discounts or work changes before marking this appointment complete.
+            Completing the appointment can trigger final balance collection and locks
+            paid invoices for tax/payment accuracy.
+          </div>
+        )}
 
       <div className="grid gap-6 md:grid-cols-2">
         {/* Customer Info */}
@@ -1131,6 +1143,14 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                           onChange={(e) => setCouponCode(e.target.value)}
                           className="h-8 text-xs uppercase"
                         />
+                        {couponCode.trim() && (
+                          <p className="mt-1 text-[10px] text-muted-foreground">
+                            Saves as{" "}
+                            <span className="font-mono">
+                              {normalizedCouponPreview || "COUPON"}
+                            </span>
+                          </p>
+                        )}
                       </div>
                       <div>
                         <Select

--- a/components/admin/coupons-client.tsx
+++ b/components/admin/coupons-client.tsx
@@ -32,6 +32,7 @@ import {
   Percent,
   Ticket,
 } from "lucide-react";
+import { normalizeStripeCouponCode } from "@/convex/lib/coupons";
 
 interface StripeCoupon {
   id: string;
@@ -85,7 +86,8 @@ export default function CouponsClient() {
 
   const handleCreateCoupon = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!couponCode.trim()) {
+    const normalizedCouponCode = normalizeStripeCouponCode(couponCode);
+    if (!normalizedCouponCode) {
       toast.error("Coupon code is required");
       return;
     }
@@ -96,13 +98,13 @@ export default function CouponsClient() {
 
     setIsSubmitting(true);
     try {
-      await createCoupon({
-        couponCode: couponCode.trim().toUpperCase(),
+      const result = await createCoupon({
+        couponCode: normalizedCouponCode,
         discountType,
         discountValue: Number(discountValue),
         duration,
       });
-      toast.success(`Coupon ${couponCode.toUpperCase()} created successfully`);
+      toast.success(`Coupon ${result.id} created successfully`);
       setShowCreateDialog(false);
       
       // Reset form
@@ -150,6 +152,7 @@ export default function CouponsClient() {
   const totalCoupons = coupons?.length || 0;
   const activeCouponsCount = coupons?.filter((c) => c.valid).length || 0;
   const totalRedemptions = coupons?.reduce((sum, c) => sum + (c.times_redeemed || 0), 0) || 0;
+  const normalizedCouponPreview = normalizeStripeCouponCode(couponCode);
 
   return (
     <div className="space-y-6 animate-fade-in">
@@ -335,7 +338,11 @@ export default function CouponsClient() {
                 required
               />
               <p className="text-[10px] text-muted-foreground">
-                This is the code your customers will use and must be unique.
+                Spaces and symbols are saved as underscores. Customers will use{" "}
+                <span className="font-mono font-medium">
+                  {normalizedCouponPreview || "THIS_FORMAT"}
+                </span>
+                .
               </p>
             </div>
 

--- a/components/admin/invoice-detail-client.tsx
+++ b/components/admin/invoice-detail-client.tsx
@@ -43,6 +43,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { formatDateString } from "@/lib/time";
+import { normalizeStripeCouponCode } from "@/convex/lib/coupons";
 
 type Props = {
   invoiceId: Id<"invoices">;
@@ -117,7 +118,8 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
 
   const handleApplyDiscount = async () => {
     if (!invoice) return;
-    if (!couponCode.trim()) {
+    const normalizedCouponCode = normalizeStripeCouponCode(couponCode);
+    if (!normalizedCouponCode) {
       toast.error("Please enter a coupon code");
       return;
     }
@@ -130,7 +132,7 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
     try {
       await applyCouponToInvoice({
         invoiceId: invoice._id,
-        couponCode: couponCode.trim().toUpperCase(),
+        couponCode: normalizedCouponCode,
         discountType,
         discountValue: Number(discountValue),
       });
@@ -164,6 +166,7 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
       setIsApplyingDiscount(false);
     }
   };
+  const normalizedCouponPreview = normalizeStripeCouponCode(couponCode);
 
   useEffect(() => {
     if (!invoice) return;
@@ -441,6 +444,14 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
                       onChange={(e) => setCouponCode(e.target.value)}
                       className="uppercase"
                     />
+                    {couponCode.trim() && (
+                      <p className="text-xs text-muted-foreground">
+                        Saves as{" "}
+                        <span className="font-mono">
+                          {normalizedCouponPreview || "COUPON"}
+                        </span>
+                      </p>
+                    )}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="discount-type">Discount Type</Label>

--- a/convex/lib/coupons.ts
+++ b/convex/lib/coupons.ts
@@ -1,0 +1,33 @@
+export function normalizeStripeCouponCode(value: string) {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function validateCouponInput(args: {
+  couponCode: string;
+  discountType: "percent" | "amount";
+  discountValue: number;
+}) {
+  const couponCode = normalizeStripeCouponCode(args.couponCode);
+  if (!couponCode) {
+    throw new Error("Coupon code must include at least one letter or number.");
+  }
+  if (!Number.isFinite(args.discountValue) || args.discountValue <= 0) {
+    throw new Error("Discount value must be greater than zero.");
+  }
+  if (args.discountType === "percent" && args.discountValue > 100) {
+    throw new Error("Percentage discounts cannot be greater than 100%.");
+  }
+
+  return {
+    couponCode,
+    discountValue:
+      args.discountType === "amount"
+        ? Math.round(args.discountValue * 100) / 100
+        : args.discountValue,
+  };
+}

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -2635,6 +2635,56 @@ describe("payments", () => {
     );
   });
 
+  test("createStripeCoupon normalizes spaces for Stripe coupon ids", async () => {
+    const t = convexTest(schema, modules);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-coupon@test.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-coupon@test.com",
+    });
+    const couponBodies: string[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, options?: RequestInit) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        const body =
+          options?.body instanceof URLSearchParams
+            ? options.body.toString()
+            : typeof options?.body === "string"
+              ? options.body
+              : "";
+
+        if (urlString.endsWith("/coupons") && options?.method === "POST") {
+          couponBodies.push(body);
+          return {
+            ok: true,
+            json: async () => ({ id: "25_REVIEW" }),
+          } as Response;
+        }
+
+        return { ok: true, json: async () => ({ id: "stripe_test_123" }) } as Response;
+      }),
+    );
+
+    const result = await asAdmin.action(api.payments.createStripeCoupon, {
+      couponCode: "25 REVIEW",
+      discountType: "amount",
+      discountValue: 25,
+      duration: "once",
+    });
+
+    expect(result).toEqual({ success: true, id: "25_REVIEW" });
+    expect(couponBodies[0]).toContain("id=25_REVIEW");
+    expect(couponBodies[0]).toContain("amount_off=2500");
+  });
+
   test("applyCouponToInvoice and removeDiscountFromInvoice", async () => {
     const t = convexTest(schema, modules);
     const userId = await createTestUser(t, true);
@@ -2734,7 +2784,7 @@ describe("payments", () => {
     // 1. Apply a coupon
     const applyResult = await asAdmin.action(api.payments.applyCouponToInvoice, {
       invoiceId,
-      couponCode: "SAVE20",
+      couponCode: "25 REVIEW",
       discountType: "percent",
       discountValue: 20,
     });
@@ -2746,7 +2796,7 @@ describe("payments", () => {
 
     // Verify database was updated
     let invoice = await t.run(async (ctx: any) => ctx.db.get(invoiceId));
-    expect(invoice?.couponCode).toBe("SAVE20");
+    expect(invoice?.couponCode).toBe("25_REVIEW");
     expect(invoice?.discountAmount).toBe(20);
     expect(invoice?.total).toBe(80);
     expect(invoice?.remainingBalance).toBe(30);

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -12,6 +12,7 @@ import { api, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { stripeClient } from "./stripeClient";
 import { BOOKING_BLOCK_MINUTES } from "./lib/booking";
+import { validateCouponInput } from "./lib/coupons";
 import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
 const paymentsInternal: any = (internal as any).payments;
@@ -50,10 +51,17 @@ async function stripeApiCall(endpoint: string, options: RequestInit = {}) {
 
       if (!response.ok) {
         const error = await response.text();
+        let stripeMessage = error;
+        try {
+          const parsed = JSON.parse(error);
+          stripeMessage = parsed?.error?.message || error;
+        } catch {
+          // Keep the raw Stripe body when it is not JSON.
+        }
         const shouldRetry =
           response.status === 429 || response.status >= 500;
         const stripeError = new Error(
-          `Stripe API error: ${response.status} ${error}`,
+          `Stripe API error: ${response.status} ${stripeMessage}`,
         );
 
         if (!shouldRetry || attempt === STRIPE_API_MAX_ATTEMPTS) {
@@ -1769,6 +1777,7 @@ export const applyCouponToInvoice = action({
     stripeInvoiceUrl?: string;
   }> => {
     await requireAdminRole(ctx);
+    const couponInput = validateCouponInput(args);
 
     const invoice: any = await ctx.runQuery(internal.invoices.getByIdInternal, {
       invoiceId: args.invoiceId,
@@ -1783,39 +1792,39 @@ export const applyCouponToInvoice = action({
     // 1. Check if Coupon exists in Stripe. If not, create it.
     let couponExists = false;
     try {
-      await stripeApiCall(`coupons/${encodeURIComponent(args.couponCode)}`, {
+      await stripeApiCall(`coupons/${encodeURIComponent(couponInput.couponCode)}`, {
         method: "GET",
       });
       couponExists = true;
     } catch {
-      console.log(`[payments] Coupon ${args.couponCode} not found in Stripe, will attempt to create it.`);
+      console.log(`[payments] Coupon ${couponInput.couponCode} not found in Stripe, will attempt to create it.`);
     }
 
     if (!couponExists) {
       const bodyParams = new URLSearchParams({
-        id: args.couponCode,
-        name: args.couponCode,
+        id: couponInput.couponCode,
+        name: couponInput.couponCode,
         duration: "once",
       });
       if (args.discountType === "percent") {
-        bodyParams.append("percent_off", args.discountValue.toString());
+        bodyParams.append("percent_off", couponInput.discountValue.toString());
       } else {
-        bodyParams.append("amount_off", Math.round(args.discountValue * 100).toString());
+        bodyParams.append("amount_off", Math.round(couponInput.discountValue * 100).toString());
         bodyParams.append("currency", "usd");
       }
       await stripeApiCall("coupons", {
         method: "POST",
         body: bodyParams,
       });
-      console.log(`[payments] Successfully created Stripe coupon ${args.couponCode}`);
+      console.log(`[payments] Successfully created Stripe coupon ${couponInput.couponCode}`);
     }
 
     // 2. Calculate local discount values
     let discountAmount = 0;
     if (args.discountType === "percent") {
-      discountAmount = parseFloat((invoice.subtotal * (args.discountValue / 100)).toFixed(2));
+      discountAmount = parseFloat((invoice.subtotal * (couponInput.discountValue / 100)).toFixed(2));
     } else {
-      discountAmount = Math.min(args.discountValue, invoice.subtotal);
+      discountAmount = Math.min(couponInput.discountValue, invoice.subtotal);
     }
 
     const newTotal = parseFloat((invoice.subtotal + invoice.tax - discountAmount).toFixed(2));
@@ -1833,7 +1842,7 @@ export const applyCouponToInvoice = action({
     // 4. Update the local invoice in Convex
     await ctx.runMutation(internal.invoices.updateDiscount, {
       invoiceId: args.invoiceId,
-      couponCode: args.couponCode,
+      couponCode: couponInput.couponCode,
       discountAmount,
       total: newTotal,
       remainingBalance: newRemainingBalance,
@@ -2894,17 +2903,18 @@ export const createStripeCoupon = action({
   }),
   handler: async (ctx, args): Promise<{ success: boolean; id: string }> => {
     await requireAdminRole(ctx);
+    const couponInput = validateCouponInput(args);
 
     const bodyParams = new URLSearchParams({
-      id: args.couponCode.trim().toUpperCase(),
-      name: args.couponCode.trim().toUpperCase(),
+      id: couponInput.couponCode,
+      name: couponInput.couponCode,
       duration: args.duration,
     });
 
     if (args.discountType === "percent") {
-      bodyParams.append("percent_off", args.discountValue.toString());
+      bodyParams.append("percent_off", couponInput.discountValue.toString());
     } else {
-      bodyParams.append("amount_off", Math.round(args.discountValue * 100).toString());
+      bodyParams.append("amount_off", Math.round(couponInput.discountValue * 100).toString());
       bodyParams.append("currency", "usd");
     }
 


### PR DESCRIPTION
## Summary
- Normalize coupon codes before sending them to Stripe, so entries like 25 REVIEW become 25_REVIEW instead of causing a Stripe regex error.
- Reuse the same normalization in coupon creation, appointment discount application, and invoice discount application.
- Add appointment-detail guidance that discounts/work changes should be applied before completion because completion can trigger final collection and paid invoices are locked.

## Implementation Notes
- Added a shared coupon helper for Stripe-safe coupon IDs and discount validation.
- Improved Stripe error messages to surface the Stripe error message instead of the full raw response body.
- Stored normalized coupon codes on invoices so Stripe and Convex stay aligned.

## Testing Notes
- pnpm exec tsc --noEmit
- pnpm test:once convex/payments.test.ts
- pnpm lint
- pnpm test:once
- pnpm build

Closes #85