### PR TITLE
fix: keep appointments editable before completion

### DIFF
--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -530,7 +530,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
       return groups;
     }, {}),
   );
-  const canEdit = data.status === "pending" || data.status === "confirmed";
+  const canEdit = ["pending", "confirmed", "in_progress"].includes(data.status);
   const canEditBilling =
     !!invoice &&
     (invoice.paymentOption ?? "deposit") === "deposit" &&
@@ -556,7 +556,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
               Edit
             </Button>
           )}
-          {["confirmed", "in_progress"].includes(data.status) && !editing && (
+          {canEdit && !editing && (
             <Button size="sm" variant="outline" onClick={startWorkAdjustment}>
               <Wrench className="mr-2 h-4 w-4" />
               Adjust Work
@@ -623,17 +623,20 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
       {data.status === "pending" && invoice?.depositPaid && (
         <div className="rounded-md border border-yellow-200 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-800 p-4">
           <p className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
-            Deposit paid — review details and confirm to generate the Stripe invoice for the remaining balance.
+            Deposit paid — you can still edit the appointment, adjust work, or
+            apply discounts before completion. Confirming keeps the job moving
+            and generates the Stripe invoice for the remaining balance.
           </p>
         </div>
       )}
-      {["confirmed", "in_progress"].includes(data.status) &&
+      {canEdit &&
         invoice &&
         invoice.status !== "paid" && (
           <div className="rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-100">
-            Apply discounts or work changes before marking this appointment complete.
-            Completing the appointment can trigger final balance collection and locks
-            paid invoices for tax/payment accuracy.
+            You can edit appointment details, adjust work, and apply discounts
+            until completion. Complete only after the invoice reflects the final
+            work, because completion can trigger final balance collection and
+            locks paid invoices for tax/payment accuracy.
           </div>
         )}
 

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -24,7 +24,11 @@ async function expectConvexErrorCode(
 describe("appointments", () => {
   async function createAdjustmentFixture(
     t: any,
-    options: { invoiceStatus?: "draft" | "open" | "paid"; depositPaid?: boolean } = {},
+    options: {
+      appointmentStatus?: "pending" | "confirmed" | "in_progress" | "completed";
+      invoiceStatus?: "draft" | "sent" | "paid" | "overdue";
+      depositPaid?: boolean;
+    } = {},
   ) {
     await seedBookingSetup(t, {
       includeBookableService: false,
@@ -135,7 +139,9 @@ describe("appointments", () => {
     );
 
     await t.run(async (ctx: any) => {
-      await ctx.db.patch(appointmentId, { status: "confirmed" });
+      await ctx.db.patch(appointmentId, {
+        status: options.appointmentStatus ?? "confirmed",
+      });
       await ctx.db.patch(invoiceId, {
         status: options.invoiceStatus ?? "draft",
         depositPaid: options.depositPaid ?? false,
@@ -546,6 +552,35 @@ describe("appointments", () => {
       durationDelta: 30,
       invoiceAction: "updated_open_invoice",
     });
+  });
+
+  test("work adjustment is available before an appointment is confirmed", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      invoiceId,
+      vehicleId,
+      baseServiceId,
+    } = await createAdjustmentFixture(t, { appointmentStatus: "pending" });
+
+    const result = await asAdmin.mutation(api.appointments.applyWorkAdjustment, {
+      appointmentId,
+      vehicleIds: [vehicleId],
+      serviceIds: [baseServiceId],
+      petFeeVehicleIds: [vehicleId],
+      reason: "Pet hair added before confirmation",
+    });
+
+    expect(result.invoiceAction).toBe("updated_open_invoice");
+    const updated = await t.run(async (ctx: any) => {
+      const appointment = await ctx.db.get(appointmentId);
+      const invoice = await ctx.db.get(invoiceId);
+      return { appointment, invoice };
+    });
+    expect(updated.appointment?.status).toBe("pending");
+    expect(updated.appointment?.totalPrice).toBe(150);
+    expect(updated.invoice?.total).toBe(150);
   });
 
   test("work adjustment can add another saved vehicle", async () => {

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -1160,8 +1160,10 @@ export const applyWorkAdjustment = mutation({
 
     const appointment = await ctx.db.get(args.appointmentId);
     if (!appointment) throw new Error("Appointment not found");
-    if (!["confirmed", "in_progress"].includes(appointment.status)) {
-      throw new Error("Only confirmed or in-progress appointments can be adjusted.");
+    if (!["pending", "confirmed", "in_progress"].includes(appointment.status)) {
+      throw new Error(
+        "Only pending, confirmed, or in-progress appointments can be adjusted.",
+      );
     }
 
     const oldPetFeeVehicleIds = appointment.petFeeVehicleIds ?? [];


### PR DESCRIPTION
## Summary
- Keep the appointment Edit and Adjust Work actions available while a job is pending, confirmed, or in progress.
- Allow backend work adjustments on pending appointments, so admins do not need to hold jobs in pending just to make service/pet-fee/vehicle changes.
- Clarify appointment-detail copy: edits, work changes, and discounts are allowed before completion; completion can trigger final balance collection and paid invoice locking.

## Implementation Notes
- Completed/cancelled appointments remain outside the normal edit/adjust path.
- Existing paid-invoice safeguards are unchanged: paid invoice reductions still require refund/credit workflow.

## Testing Notes
- pnpm exec tsc --noEmit
- pnpm test:once convex/appointments.test.ts
- pnpm lint
- pnpm test:once
- pnpm build

Closes #87