### PR TITLE
fix: repair onboarding photo uploads and custom invoice coupons

### DIFF
--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -156,20 +156,18 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
       toast.error("Please enter a coupon code");
       return;
     }
-    if (discountValue === "" || discountValue <= 0) {
-      toast.error("Please enter a valid discount value");
-      return;
-    }
+    const hasManualDiscountValue = discountValue !== "" && Number(discountValue) > 0;
 
     setIsApplyingDiscount(true);
     try {
       await applyCouponToInvoice({
         invoiceId: invoice._id,
         couponCode: normalizedCouponCode,
-        discountType,
-        discountValue: Number(discountValue),
+        ...(hasManualDiscountValue
+          ? { discountType, discountValue: Number(discountValue) }
+          : {}),
       });
-      toast.success("Discount applied successfully");
+      toast.success(invoice.couponCode ? "Discount replaced successfully" : "Discount applied successfully");
       setCouponCode("");
       setDiscountValue("");
       router.refresh();
@@ -530,6 +528,8 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
       return groups;
     }, {}),
   );
+  const canPreviewInlinePhoto = (photo: AppointmentBeforePhoto) =>
+    !["image/heic", "image/heif"].includes(photo.contentType.toLowerCase());
   const canEdit = ["pending", "confirmed", "in_progress"].includes(data.status);
   const canEditBilling =
     !!invoice &&
@@ -940,7 +940,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
                       {photos.map((photo) => (
                         <div key={photo.key} className="overflow-hidden rounded-md border">
-                          {photo.signedUrl ? (
+                          {photo.signedUrl && canPreviewInlinePhoto(photo) ? (
                             <button
                               type="button"
                               className="block w-full text-left"
@@ -957,6 +957,20 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                                 alt={photo.fileName}
                                 className="aspect-[4/3] w-full object-cover"
                               />
+                            </button>
+                          ) : photo.signedUrl ? (
+                            <button
+                              type="button"
+                              className="flex aspect-[4/3] w-full flex-col items-center justify-center gap-2 bg-muted p-4 text-center text-xs text-muted-foreground"
+                              onClick={() =>
+                                setPreviewPhoto({
+                                  url: photo.signedUrl!,
+                                  fileName: photo.fileName,
+                                })
+                              }
+                            >
+                              <Images className="h-6 w-6" />
+                              Open photo
                             </button>
                           ) : (
                             <div className="flex aspect-[4/3] items-center justify-center bg-muted p-4 text-center text-xs text-muted-foreground">
@@ -1117,7 +1131,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                 </h4>
 
                 {invoice.couponCode ? (
-                  <div className="flex items-center justify-between gap-2 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
                     <div className="flex items-center gap-1.5 min-w-0">
                       <Badge variant="outline" className="border-primary/30 bg-primary/5 text-primary truncate">
                         {invoice.couponCode}
@@ -1136,8 +1150,8 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                       Remove
                     </Button>
                   </div>
-                ) : (
-                  <div className="space-y-3">
+                ) : null}
+                <div className="space-y-3">
                     <div className="grid gap-2 grid-cols-3">
                       <div className="col-span-2">
                         <Input
@@ -1154,6 +1168,10 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                             </span>
                           </p>
                         )}
+                        <p className="mt-1 text-[10px] text-muted-foreground">
+                          Existing Stripe coupons only need the code. Add a
+                          value to create or replace a one-off discount.
+                        </p>
                       </div>
                       <div>
                         <Select
@@ -1174,7 +1192,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                       <div className="flex-1">
                         <Input
                           type="number"
-                          placeholder={discountType === "percent" ? "Percentage (e.g. 20)" : "Amount (e.g. 15)"}
+                          placeholder={discountType === "percent" ? "Optional %" : "Optional $"}
                           value={discountValue}
                           onChange={(e) => setDiscountValue(e.target.value === "" ? "" : Number(e.target.value))}
                           className="h-8 text-xs"
@@ -1187,7 +1205,11 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                         onClick={handleApplyDiscount}
                         disabled={isApplyingDiscount}
                       >
-                        {isApplyingDiscount ? "Applying..." : "Apply"}
+                        {isApplyingDiscount
+                          ? "Applying..."
+                          : invoice.couponCode
+                            ? "Replace"
+                            : "Apply"}
                       </Button>
                     </div>
 
@@ -1247,7 +1269,6 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                       </Button>
                     </div>
                   </div>
-                )}
               </div>
             )}
           </CardContent>
@@ -1551,12 +1572,19 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
             <DialogTitle>{previewPhoto?.fileName || "Before Photo"}</DialogTitle>
           </DialogHeader>
           {previewPhoto && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={previewPhoto.url}
-              alt={previewPhoto.fileName}
-              className="max-h-[75vh] w-full rounded-md object-contain"
-            />
+            <div className="space-y-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewPhoto.url}
+                alt={previewPhoto.fileName}
+                className="max-h-[75vh] w-full rounded-md object-contain"
+              />
+              <Button variant="outline" asChild>
+                <a href={previewPhoto.url} target="_blank" rel="noreferrer">
+                  Open original
+                </a>
+              </Button>
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/components/admin/invoice-detail-client.tsx
+++ b/components/admin/invoice-detail-client.tsx
@@ -123,20 +123,18 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
       toast.error("Please enter a coupon code");
       return;
     }
-    if (discountValue === "" || discountValue <= 0) {
-      toast.error("Please enter a valid discount value");
-      return;
-    }
+    const hasManualDiscountValue = discountValue !== "" && Number(discountValue) > 0;
 
     setIsApplyingDiscount(true);
     try {
       await applyCouponToInvoice({
         invoiceId: invoice._id,
         couponCode: normalizedCouponCode,
-        discountType,
-        discountValue: Number(discountValue),
+        ...(hasManualDiscountValue
+          ? { discountType, discountValue: Number(discountValue) }
+          : {}),
       });
-      toast.success("Discount applied successfully");
+      toast.success(invoice.couponCode ? "Discount replaced successfully" : "Discount applied successfully");
       setCouponCode("");
       setDiscountValue("");
       router.refresh();
@@ -416,7 +414,7 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
           </CardHeader>
           <CardContent className="space-y-4">
             {invoice.couponCode ? (
-              <div className="flex items-center justify-between p-3 border rounded-md bg-primary/5">
+              <div className="flex flex-wrap items-center justify-between gap-3 p-3 border rounded-md bg-primary/5">
                 <div>
                   <p className="font-semibold text-primary">Active Discount: {invoice.couponCode}</p>
                   <p className="text-xs text-muted-foreground mt-0.5">
@@ -432,8 +430,8 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
                   Remove Discount
                 </Button>
               </div>
-            ) : (
-              <div className="space-y-4">
+            ) : null}
+            <div className="space-y-4">
                 <div className="grid gap-4 md:grid-cols-3">
                   <div className="space-y-2 col-span-2">
                     <Label htmlFor="coupon-code">Coupon / Promo Code</Label>
@@ -452,6 +450,10 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
                         </span>
                       </p>
                     )}
+                    <p className="text-xs text-muted-foreground">
+                      Enter an existing Stripe coupon code, or add a type and
+                      value below to create a one-off discount.
+                    </p>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="discount-type">Discount Type</Label>
@@ -475,7 +477,7 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
                     <Input
                       id="discount-value"
                       type="number"
-                      placeholder={discountType === "percent" ? "e.g. 20 for 20%" : "e.g. 15 for $15"}
+                      placeholder={discountType === "percent" ? "Optional, e.g. 20" : "Optional, e.g. 15"}
                       value={discountValue}
                       onChange={(e) => setDiscountValue(e.target.value === "" ? "" : Number(e.target.value))}
                       min={1}
@@ -485,7 +487,11 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
                       disabled={isApplyingDiscount}
                       className="whitespace-nowrap"
                     >
-                      {isApplyingDiscount ? "Applying..." : "Apply Discount"}
+                      {isApplyingDiscount
+                        ? "Applying..."
+                        : invoice.couponCode
+                          ? "Replace Discount"
+                          : "Apply Discount"}
                     </Button>
                   </div>
                 </div>
@@ -546,7 +552,6 @@ export default function InvoiceDetailClient({ invoiceId }: Props) {
                   </Button>
                 </div>
               </div>
-            )}
           </CardContent>
         </Card>
       )}

--- a/components/forms/vehicle-lookup-card.tsx
+++ b/components/forms/vehicle-lookup-card.tsx
@@ -72,6 +72,17 @@ const ALLOWED_PHOTO_TYPES = new Set([
   "image/png",
   "image/webp",
   "image/gif",
+  "image/heic",
+  "image/heif",
+]);
+const ALLOWED_PHOTO_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".gif",
+  ".heic",
+  ".heif",
 ]);
 
 function parseVehicleQuery(query: string) {
@@ -90,8 +101,31 @@ function isValidYear(year: string) {
   return /^\d{4}$/.test(year);
 }
 
+function getFileExtension(fileName: string) {
+  const normalized = fileName.toLowerCase().trim();
+  const lastDotIndex = normalized.lastIndexOf(".");
+  return lastDotIndex >= 0 ? normalized.slice(lastDotIndex) : "";
+}
+
+function getUploadContentType(file: File) {
+  if (file.type) return file.type;
+  const extension = getFileExtension(file.name);
+  if (extension === ".jpg" || extension === ".jpeg") return "image/jpeg";
+  if (extension === ".png") return "image/png";
+  if (extension === ".webp") return "image/webp";
+  if (extension === ".gif") return "image/gif";
+  if (extension === ".heic") return "image/heic";
+  if (extension === ".heif") return "image/heif";
+  return "application/octet-stream";
+}
+
 function isAllowedPhoto(file: File) {
-  return ALLOWED_PHOTO_TYPES.has(file.type) && file.size <= MAX_PHOTO_SIZE_BYTES;
+  const extension = getFileExtension(file.name);
+  return (
+    file.size <= MAX_PHOTO_SIZE_BYTES &&
+    (ALLOWED_PHOTO_TYPES.has(file.type) ||
+      (file.type === "" && ALLOWED_PHOTO_EXTENSIONS.has(extension)))
+  );
 }
 
 export function VehicleLookupCard({
@@ -246,7 +280,7 @@ export function VehicleLookupCard({
 
     const invalidFile = selectedFiles.find((file) => !isAllowedPhoto(file));
     if (invalidFile) {
-      toast.error("Before photos must be JPG, PNG, WEBP, or GIF under 10MB.");
+      toast.error("Before photos must be JPG, PNG, WEBP, GIF, HEIC, or HEIF under 10MB.");
       return;
     }
 
@@ -254,13 +288,14 @@ export function VehicleLookupCard({
     try {
       const uploadedPhotos: BeforePhoto[] = [];
       for (const file of selectedFiles) {
+        const contentType = getUploadContentType(file);
         const upload = await createBeforePhotoUploadUrl({
           fileName: file.name,
-          contentType: file.type,
+          contentType,
         });
         const response = await fetch(upload.url, {
           method: "PUT",
-          headers: { "Content-Type": file.type },
+          headers: { "Content-Type": contentType },
           body: file,
         });
         if (!response.ok) {
@@ -269,7 +304,7 @@ export function VehicleLookupCard({
         uploadedPhotos.push({
           key: upload.key,
           fileName: file.name,
-          contentType: file.type,
+          contentType,
           sizeBytes: file.size,
           uploadedAt: Date.now(),
         });
@@ -488,7 +523,7 @@ export function VehicleLookupCard({
                     Upload
                     <input
                       type="file"
-                      accept="image/jpeg,image/png,image/webp,image/gif"
+                      accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,.heic,.heif"
                       multiple
                       className="sr-only"
                       onChange={(event) => {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as http from "../http.js";
 import type * as invoices from "../invoices.js";
 import type * as lib_address from "../lib/address.js";
 import type * as lib_booking from "../lib/booking.js";
+import type * as lib_coupons from "../lib/coupons.js";
 import type * as lib_notificationMessages from "../lib/notificationMessages.js";
 import type * as lib_notificationSettings from "../lib/notificationSettings.js";
 import type * as lib_pricing from "../lib/pricing.js";
@@ -76,6 +77,7 @@ declare const fullApi: ApiFromModules<{
   invoices: typeof invoices;
   "lib/address": typeof lib_address;
   "lib/booking": typeof lib_booking;
+  "lib/coupons": typeof lib_coupons;
   "lib/notificationMessages": typeof lib_notificationMessages;
   "lib/notificationSettings": typeof lib_notificationSettings;
   "lib/pricing": typeof lib_pricing;

--- a/convex/bookingDrafts.test.ts
+++ b/convex/bookingDrafts.test.ts
@@ -1,10 +1,35 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api";
+import { r2 } from "./r2";
 import schema from "./schema";
 import { modules } from "./test.setup";
 
 describe("bookingDrafts out-of-area requests", () => {
+  test("creates upload URLs for mobile HEIC before photos", async () => {
+    const t = convexTest(schema, modules);
+    const generateUploadUrlSpy = vi
+      .spyOn(r2, "generateUploadUrl")
+      .mockResolvedValue({
+        key: "booking-before-photos/test/canam.heic",
+        url: "https://example.com/upload",
+      });
+
+    try {
+      const upload = await t.mutation(api.bookingDrafts.createBeforePhotoUploadUrl, {
+        fileName: "can-am-before.HEIC",
+        contentType: "image/heic",
+      });
+
+      expect(upload.url).toBe("https://example.com/upload");
+      expect(generateUploadUrlSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^booking-before-photos\/.*can-am-before\.HEIC$/),
+      );
+    } finally {
+      generateUploadUrlSpy.mockRestore();
+    }
+  });
+
   test("saves a public out-of-area review request for admin follow-up", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -207,8 +207,18 @@ function validateBeforePhotoFile(fileName: string, contentType: string) {
     "image/png",
     "image/webp",
     "image/gif",
+    "image/heic",
+    "image/heif",
   ]);
-  const allowedExtensions = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif"]);
+  const allowedExtensions = new Set([
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".webp",
+    ".gif",
+    ".heic",
+    ".heif",
+  ]);
   if (
     !allowedContentTypes.has(normalizeContentType(contentType)) ||
     !allowedExtensions.has(getFileExtension(fileName))

--- a/convex/lib/coupons.ts
+++ b/convex/lib/coupons.ts
@@ -9,24 +9,30 @@ export function normalizeStripeCouponCode(value: string) {
 
 export function validateCouponInput(args: {
   couponCode: string;
-  discountType: "percent" | "amount";
-  discountValue: number;
+  discountType?: "percent" | "amount";
+  discountValue?: number;
 }) {
   const couponCode = normalizeStripeCouponCode(args.couponCode);
   if (!couponCode) {
     throw new Error("Coupon code must include at least one letter or number.");
   }
-  if (!Number.isFinite(args.discountValue) || args.discountValue <= 0) {
-    throw new Error("Discount value must be greater than zero.");
-  }
-  if (args.discountType === "percent" && args.discountValue > 100) {
-    throw new Error("Percentage discounts cannot be greater than 100%.");
+
+  if (args.discountType !== undefined || args.discountValue !== undefined) {
+    if (!args.discountType) {
+      throw new Error("Discount type is required when creating a coupon.");
+    }
+    if (!Number.isFinite(args.discountValue) || (args.discountValue ?? 0) <= 0) {
+      throw new Error("Discount value must be greater than zero.");
+    }
+    if (args.discountType === "percent" && (args.discountValue ?? 0) > 100) {
+      throw new Error("Percentage discounts cannot be greater than 100%.");
+    }
   }
 
   return {
     couponCode,
     discountValue:
-      args.discountType === "amount"
+      args.discountType === "amount" && args.discountValue !== undefined
         ? Math.round(args.discountValue * 100) / 100
         : args.discountValue,
   };

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -2814,4 +2814,64 @@ describe("payments", () => {
     expect(invoice?.total).toBe(100);
     expect(invoice?.remainingBalance).toBe(50);
   });
+
+  test("applyCouponToInvoice can use an existing Stripe coupon by code only", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t, true);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin@test.com",
+        role: "admin",
+      });
+    });
+
+    const { invoiceId } = await createTestAppointmentWithInvoice(
+      t,
+      userId,
+      adminId,
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+
+        if (urlString.includes("/coupons/VIP_CANAM")) {
+          return {
+            ok: true,
+            json: async () => ({
+              id: "VIP_CANAM",
+              valid: true,
+              amount_off: 2500,
+              currency: "usd",
+            }),
+          } as Response;
+        }
+
+        return { ok: true, json: async () => ({ id: "stripe_test_123" }) } as Response;
+      }),
+    );
+
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin@test.com",
+    });
+
+    const applyResult = await asAdmin.action(api.payments.applyCouponToInvoice, {
+      invoiceId,
+      couponCode: "VIP CANAM",
+    });
+
+    expect(applyResult.success).toBe(true);
+    expect(applyResult.discountAmount).toBe(25);
+    expect(applyResult.newTotal).toBe(75);
+    expect(applyResult.newRemainingBalance).toBe(25);
+
+    const invoice = await t.run(async (ctx: any) => ctx.db.get(invoiceId));
+    expect(invoice?.couponCode).toBe("VIP_CANAM");
+    expect(invoice?.discountAmount).toBe(25);
+    expect(invoice?.total).toBe(75);
+    expect(invoice?.remainingBalance).toBe(25);
+  });
 });

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -298,6 +298,28 @@ function mapStripeInvoiceStatusToLocalStatus(
   return "sent";
 }
 
+function getDiscountFromStripeCoupon(stripeCoupon: any): {
+  discountType: "percent" | "amount";
+  discountValue: number;
+} {
+  if (!stripeCoupon || stripeCoupon.valid === false) {
+    throw new Error("This Stripe coupon is not active.");
+  }
+  if (typeof stripeCoupon.percent_off === "number" && stripeCoupon.percent_off > 0) {
+    return {
+      discountType: "percent",
+      discountValue: stripeCoupon.percent_off,
+    };
+  }
+  if (typeof stripeCoupon.amount_off === "number" && stripeCoupon.amount_off > 0) {
+    return {
+      discountType: "amount",
+      discountValue: Math.round(stripeCoupon.amount_off) / 100,
+    };
+  }
+  throw new Error("This Stripe coupon does not have a supported discount amount.");
+}
+
 async function getStripeInvoiceById(stripeInvoiceId: string): Promise<any> {
   return await stripeApiCall(`invoices/${stripeInvoiceId}`, {
     method: "GET",
@@ -1754,8 +1776,8 @@ export const applyCouponToInvoice = action({
   args: {
     invoiceId: v.id("invoices"),
     couponCode: v.string(),
-    discountType: v.union(v.literal("percent"), v.literal("amount")),
-    discountValue: v.number(),
+    discountType: v.optional(v.union(v.literal("percent"), v.literal("amount"))),
+    discountValue: v.optional(v.number()),
   },
   returns: v.object({
     success: v.boolean(),
@@ -1789,27 +1811,32 @@ export const applyCouponToInvoice = action({
       throw new Error("Paid invoices cannot be modified");
     }
 
-    // 1. Check if Coupon exists in Stripe. If not, create it.
-    let couponExists = false;
+    // 1. Check if Coupon exists in Stripe. If not, create it from supplied terms.
+    let stripeCoupon: any | null = null;
     try {
-      await stripeApiCall(`coupons/${encodeURIComponent(couponInput.couponCode)}`, {
+      stripeCoupon = await stripeApiCall(`coupons/${encodeURIComponent(couponInput.couponCode)}`, {
         method: "GET",
       });
-      couponExists = true;
     } catch {
       console.log(`[payments] Coupon ${couponInput.couponCode} not found in Stripe, will attempt to create it.`);
     }
 
-    if (!couponExists) {
+    if (!stripeCoupon) {
+      if (!args.discountType || couponInput.discountValue === undefined) {
+        throw new Error(
+          "Coupon not found in Stripe. Enter a discount type and value, or create the coupon first.",
+        );
+      }
+      const discountValue = couponInput.discountValue;
       const bodyParams = new URLSearchParams({
         id: couponInput.couponCode,
         name: couponInput.couponCode,
         duration: "once",
       });
       if (args.discountType === "percent") {
-        bodyParams.append("percent_off", couponInput.discountValue.toString());
+        bodyParams.append("percent_off", discountValue.toString());
       } else {
-        bodyParams.append("amount_off", Math.round(couponInput.discountValue * 100).toString());
+        bodyParams.append("amount_off", Math.round(discountValue * 100).toString());
         bodyParams.append("currency", "usd");
       }
       await stripeApiCall("coupons", {
@@ -1820,11 +1847,19 @@ export const applyCouponToInvoice = action({
     }
 
     // 2. Calculate local discount values
+    const effectiveDiscount =
+      couponInput.discountValue !== undefined && args.discountType
+        ? {
+            discountType: args.discountType,
+            discountValue: couponInput.discountValue,
+          }
+        : getDiscountFromStripeCoupon(stripeCoupon);
+
     let discountAmount = 0;
-    if (args.discountType === "percent") {
-      discountAmount = parseFloat((invoice.subtotal * (couponInput.discountValue / 100)).toFixed(2));
+    if (effectiveDiscount.discountType === "percent") {
+      discountAmount = parseFloat((invoice.subtotal * (effectiveDiscount.discountValue / 100)).toFixed(2));
     } else {
-      discountAmount = Math.min(couponInput.discountValue, invoice.subtotal);
+      discountAmount = Math.min(effectiveDiscount.discountValue, invoice.subtotal);
     }
 
     const newTotal = parseFloat((invoice.subtotal + invoice.tax - discountAmount).toFixed(2));
@@ -2904,6 +2939,10 @@ export const createStripeCoupon = action({
   handler: async (ctx, args): Promise<{ success: boolean; id: string }> => {
     await requireAdminRole(ctx);
     const couponInput = validateCouponInput(args);
+    if (couponInput.discountValue === undefined) {
+      throw new Error("Discount value must be greater than zero.");
+    }
+    const discountValue = couponInput.discountValue;
 
     const bodyParams = new URLSearchParams({
       id: couponInput.couponCode,
@@ -2912,9 +2951,9 @@ export const createStripeCoupon = action({
     });
 
     if (args.discountType === "percent") {
-      bodyParams.append("percent_off", couponInput.discountValue.toString());
+      bodyParams.append("percent_off", discountValue.toString());
     } else {
-      bodyParams.append("amount_off", Math.round(couponInput.discountValue * 100).toString());
+      bodyParams.append("amount_off", Math.round(discountValue * 100).toString());
       bodyParams.append("currency", "usd");
     }
 


### PR DESCRIPTION
## Summary
- Allow customer before-photo uploads from mobile HEIC/HEIF images and preserve admin access to originals.
- Let admins apply existing Stripe coupons by code only from invoice and appointment screens.
- Keep preset one-off discounts working while allowing an active discount to be replaced instead of forcing remove-first.

## Implementation Notes
- applyCouponToInvoice now looks up an existing Stripe coupon and derives the discount amount/percent when no manual value is supplied.
- Invoice and appointment discount panels now stay editable when a discount exists.
- Booking before-photo validation accepts HEIC/HEIF and the client infers missing mobile MIME types from file extensions.

## Testing Notes
- pnpm exec convex codegen
- pnpm test:once convex/bookingDrafts.test.ts
- pnpm test:once convex/payments.test.ts
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test:once
- pnpm build

Closes #89