### PR TITLE
fix: support manual vehicle fallback and hide unpriced services

### DIFF
--- a/components/booking/booking-flow.tsx
+++ b/components/booking/booking-flow.tsx
@@ -815,6 +815,39 @@ export default function BookingFlow() {
         isValid = await step4Form.trigger();
         if (isValid) {
           const selectedStep4Data = step4Form.getValues();
+          const selectedVehicles = step3Data?.vehicles ?? [];
+          for (let idx = 0; idx < selectedVehicles.length; idx += 1) {
+            const vehicle = selectedVehicles[idx];
+            const vehicleContext = {
+              vehicleSize: (vehicle.size ?? "medium") as VehicleSize,
+              vehicleTypeId: vehicle.vehicleTypeId ?? null,
+            };
+            const selectedIds =
+              selectedStep4Data.vehicleServices?.[idx.toString()] ||
+              selectedStep4Data.serviceIds ||
+              [];
+            const selectedServices =
+              services?.filter((service) => selectedIds.includes(service._id)) ?? [];
+            const unavailableService = selectedServices.find(
+              (service) => !isServiceAvailableForVehicle(service, vehicleContext),
+            );
+            if (unavailableService) {
+              toast.error(
+                `${unavailableService.name} is not available for ${vehicle.make || "this vehicle"}. Please choose another service.`,
+              );
+              setExpandedStep4VehicleIndex(idx);
+              return;
+            }
+            const hasStandardPackage = selectedServices.some(
+              (service) => normalizeServiceType(service.serviceType) === "standard",
+            );
+            if (!hasStandardPackage) {
+              toast.error("Please choose a package for each vehicle.");
+              setExpandedStep4VehicleIndex(idx);
+              setActiveServiceSection((current) => ({ ...current, [idx]: "packages" }));
+              return;
+            }
+          }
 
           const serviceDurations: number[] = [];
           const vehicles = step3Data?.vehicles ?? [];
@@ -1616,7 +1649,16 @@ export default function BookingFlow() {
                               new Map<string, typeof sortedStandard>(),
                             );
 
-                            const currentSelection = field.value?.[vehicleKey] || [];
+                            const availableServiceIds = new Set(
+                              [
+                                ...standardServices,
+                                ...addonServices,
+                                ...subscriptionServices,
+                              ].map((service) => String(service._id)),
+                            );
+                            const currentSelection = (field.value?.[vehicleKey] || []).filter(
+                              (serviceId) => availableServiceIds.has(String(serviceId)),
+                            );
                             const activeSection = activeServiceSection[vIdx] || "packages";
 
                             const selectedPackageId = currentSelection.find(id => {

--- a/components/forms/admin/vehicle-pricing-editor.tsx
+++ b/components/forms/admin/vehicle-pricing-editor.tsx
@@ -68,7 +68,7 @@ export function VehiclePricingEditor<TForm extends FormWithVehiclePrices>({
         vehicleTypeId: vehicleType._id,
         price: 0,
         duration: defaultDuration,
-        isAvailable: true,
+        isAvailable: false,
       })) as PathValue<TForm, Path<TForm>>,
       { shouldValidate: true },
     );
@@ -94,7 +94,7 @@ export function VehiclePricingEditor<TForm extends FormWithVehiclePrices>({
         {
           price: 0,
           duration: defaultDuration,
-          isAvailable: true,
+          isAvailable: false,
         },
       ] as PathValue<TForm, Path<TForm>>,
       { shouldDirty: true, shouldValidate: true },
@@ -220,12 +220,18 @@ export function VehiclePricingEditor<TForm extends FormWithVehiclePrices>({
               <Label className="text-xs">Available</Label>
               <div className="flex h-9 items-center">
                 <Switch
-                  checked={row.isAvailable}
+                  checked={row.isAvailable && row.price > 0 && row.duration > 0}
+                  disabled={row.price <= 0 || row.duration <= 0}
                   onCheckedChange={(checked) =>
                     updateRow(index, { isAvailable: checked })
                   }
                 />
               </div>
+              {(row.price <= 0 || row.duration <= 0) && (
+                <p className="text-[10px] text-muted-foreground">
+                  Add price and minutes first.
+                </p>
+              )}
             </div>
 
             <div className="flex items-end">

--- a/components/forms/vehicle-lookup-card.tsx
+++ b/components/forms/vehicle-lookup-card.tsx
@@ -11,6 +11,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 
 type VehicleSize = "small" | "medium" | "large";
@@ -67,6 +74,11 @@ type VehicleLookupCardProps = {
 
 const MAX_PHOTOS = 6;
 const MAX_PHOTO_SIZE_BYTES = 10 * 1024 * 1024;
+const SIZE_LABELS: Record<VehicleSize, string> = {
+  small: "Small / motorcycle / ATV",
+  medium: "Car / standard",
+  large: "SUV / truck / van / RV",
+};
 const ALLOWED_PHOTO_TYPES = new Set([
   "image/jpeg",
   "image/png",
@@ -153,6 +165,13 @@ export function VehicleLookupCard({
   const [isSearching, setIsSearching] = useState(false);
   const [isClassifying, setIsClassifying] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
+  const [isManualEntryOpen, setIsManualEntryOpen] = useState(false);
+  const [manualVehicle, setManualVehicle] = useState({
+    year: value.year ?? "",
+    make: value.make ?? "",
+    model: value.model ?? "",
+    size: (value.size ?? "medium") as VehicleSize,
+  });
 
   useEffect(() => {
     const selectedVehicle = [value.year, value.make, value.model]
@@ -218,7 +237,10 @@ export function VehicleLookupCard({
       });
       onChange({
         ...nextValue,
-        size: classification.legacySize,
+        size:
+          classification.needsAdminReview || !classification.vehicleTypeId
+            ? nextValue.size ?? classification.legacySize
+            : classification.legacySize,
         vehicleTypeId: classification.vehicleTypeId as Id<"vehicleTypes"> | undefined,
         vehicleTypeName: classification.vehicleTypeName,
         classification: {
@@ -231,6 +253,7 @@ export function VehicleLookupCard({
     } catch {
       onChange({
         ...nextValue,
+        size: nextValue.size ?? "medium",
         classification: {
           source: "fallback",
           confidence: "low",
@@ -252,6 +275,36 @@ export function VehicleLookupCard({
       make: suggestion.make,
       model: suggestion.model,
     });
+  };
+
+  const acceptManualVehicle = () => {
+    const year = manualVehicle.year.trim();
+    const make = manualVehicle.make.trim();
+    const model = manualVehicle.model.trim();
+    if (!isValidYear(year) || !make || !model) {
+      toast.error("Enter a 4-digit year, make, and model.");
+      return;
+    }
+    const nextValue = {
+      ...value,
+      year,
+      make,
+      model,
+      size: manualVehicle.size,
+      vehicleTypeId: undefined,
+      vehicleTypeName: undefined,
+      classification: {
+        source: "manual" as const,
+        confidence: "low" as const,
+        rawCategory: "Manual customer entry",
+        needsAdminReview: true,
+      },
+    };
+    setQuery([year, make, model].join(" "));
+    setIsMenuOpen(false);
+    setSuggestions([]);
+    setIsManualEntryOpen(false);
+    void classifySelection(nextValue);
   };
 
   const acceptTypedVehicle = () => {
@@ -422,7 +475,7 @@ export function VehicleLookupCard({
               {isMenuOpen &&
                 (suggestions.length > 0 ||
                   isSearching ||
-                  (parseVehicleQuery(query).year && parseVehicleQuery(query).model)) && (
+                  query.trim().length >= 3) && (
                 <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-md border bg-background shadow-lg">
                   {isSearching && (
                     <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
@@ -456,9 +509,119 @@ export function VehicleLookupCard({
                       Use &quot;{query.trim()}&quot;
                     </button>
                   )}
+                  {!isSearching && suggestions.length === 0 && (
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 border-t px-3 py-2 text-left text-sm hover:bg-muted"
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        const typed = parseVehicleQuery(query);
+                        setManualVehicle((current) => ({
+                          ...current,
+                          year: typed.year || current.year,
+                          make: typed.make || current.make,
+                          model: typed.model || current.model,
+                        }));
+                        setIsManualEntryOpen(true);
+                        setIsMenuOpen(false);
+                      }}
+                    >
+                      <Check className="h-4 w-4" />
+                      Enter this vehicle manually
+                    </button>
+                  )}
                 </div>
               )}
           </div>
+
+          {isManualEntryOpen && (
+            <div className="rounded-md border bg-muted/10 p-3">
+              <div className="grid gap-3 sm:grid-cols-[96px_1fr_1fr]">
+                <div className="space-y-1">
+                  <Label htmlFor={`${title}-manual-year`}>Year</Label>
+                  <Input
+                    id={`${title}-manual-year`}
+                    inputMode="numeric"
+                    value={manualVehicle.year}
+                    onChange={(event) =>
+                      setManualVehicle((current) => ({
+                        ...current,
+                        year: event.target.value,
+                      }))
+                    }
+                    placeholder="2024"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor={`${title}-manual-make`}>Make</Label>
+                  <Input
+                    id={`${title}-manual-make`}
+                    value={manualVehicle.make}
+                    onChange={(event) =>
+                      setManualVehicle((current) => ({
+                        ...current,
+                        make: event.target.value,
+                      }))
+                    }
+                    placeholder="Can-Am"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor={`${title}-manual-model`}>Model</Label>
+                  <Input
+                    id={`${title}-manual-model`}
+                    value={manualVehicle.model}
+                    onChange={(event) =>
+                      setManualVehicle((current) => ({
+                        ...current,
+                        model: event.target.value,
+                      }))
+                    }
+                    placeholder="Spyder RT"
+                  />
+                </div>
+              </div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-[1fr_auto]">
+                <div className="space-y-1">
+                  <Label htmlFor={`${title}-manual-size`}>
+                    Pricing type
+                  </Label>
+                  <Select
+                    value={manualVehicle.size}
+                    onValueChange={(size) =>
+                      setManualVehicle((current) => ({
+                        ...current,
+                        size: size as VehicleSize,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id={`${title}-manual-size`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(["small", "medium", "large"] as VehicleSize[]).map((size) => (
+                        <SelectItem key={size} value={size}>
+                          {SIZE_LABELS[size]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-end gap-2">
+                  <Button type="button" onClick={acceptManualVehicle}>
+                    Use Vehicle
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setIsManualEntryOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
 
           {(showColor || showLicensePlate) && (
             <div className="grid gap-4 sm:grid-cols-2">

--- a/convex/lib/pricing.test.ts
+++ b/convex/lib/pricing.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
   getEffectiveServicePricingForVehicle,
+  hasAnyAvailableVehicleTypePrice,
+  isBookableStandardService,
   isServiceAvailableForVehicle,
 } from "./pricing";
 
@@ -71,6 +73,37 @@ describe("vehicle-aware service pricing", () => {
         vehicleTypeId: "van",
       }),
     ).toBe(false);
+  });
+
+  test("treats rows without price or duration as unavailable", () => {
+    const service = {
+      isActive: true,
+      serviceType: "standard" as const,
+      duration: 90,
+      vehiclePrices: [
+        {
+          vehicleTypeId: "car",
+          price: 125,
+          duration: 0,
+          isAvailable: true,
+        },
+        {
+          vehicleTypeId: "truck",
+          price: 0,
+          duration: 120,
+          isAvailable: true,
+        },
+      ],
+    };
+
+    expect(
+      getEffectiveServicePricingForVehicle(service, {
+        vehicleSize: "medium",
+        vehicleTypeId: "car",
+      }),
+    ).toEqual({ price: 125, duration: 0, isAvailable: false });
+    expect(hasAnyAvailableVehicleTypePrice(service.vehiclePrices)).toBe(false);
+    expect(isBookableStandardService(service)).toBe(false);
   });
 
   test("falls back to matching legacy size rows when a vehicle has no type id", () => {

--- a/convex/lib/pricing.ts
+++ b/convex/lib/pricing.ts
@@ -78,10 +78,11 @@ export function getEffectiveServicePricingForVehicle(
     }
 
     const price = Number.isFinite(row.price) ? row.price : 0;
+    const duration = Math.max(0, row.duration ?? fallbackDuration);
     return {
       price,
-      duration: Math.max(0, row.duration ?? fallbackDuration),
-      isAvailable: row.isAvailable && price > 0,
+      duration,
+      isAvailable: row.isAvailable && price > 0 && duration > 0,
     };
   }
 
@@ -120,16 +121,23 @@ export function hasAnyAvailableVehicleTypePrice(
 ): boolean {
   return (
     vehiclePrices?.some(
-      (price) => price.isAvailable && Number.isFinite(price.price) && price.price > 0,
+      (price) =>
+        price.isAvailable &&
+        Number.isFinite(price.price) &&
+        price.price > 0 &&
+        (price.duration ?? 0) > 0,
     ) ?? false
   );
 }
 
 export function isBookableStandardService(service: ServicePricingShape): boolean {
+  const hasVehicleTypeRows = (service.vehiclePrices?.length ?? 0) > 0;
   return (
     service.isActive === true &&
     normalizeServiceType(service.serviceType) === "standard" &&
-    hasAnyPositiveServicePrice(service)
+    (hasVehicleTypeRows
+      ? hasAnyAvailableVehicleTypePrice(service.vehiclePrices)
+      : hasAnyPositiveServicePrice(service))
   );
 }
 

--- a/convex/services.test.ts
+++ b/convex/services.test.ts
@@ -166,6 +166,66 @@ describe("services", () => {
     expect(vehicleTypes.some((vehicleType) => vehicleType.name === "Boat")).toBe(true);
   });
 
+  test("normalizes vehicle price rows without price or minutes as unavailable", async () => {
+    const t = convexTest(schema, modules);
+
+    const adminId = await t.run(async (ctx) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin-blank-pricing@test.com",
+        role: "admin",
+      });
+    });
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin-blank-pricing@test.com",
+    });
+
+    const serviceId = await asAdmin.mutation(api.services.create, {
+      name: "Selective Detail",
+      description: "Some rows are intentionally blank",
+      duration: 90,
+      vehiclePrices: [
+        {
+          vehicleTypeName: "Car",
+          price: 125,
+          duration: 90,
+          isAvailable: true,
+        },
+        {
+          vehicleTypeName: "RV",
+          price: 250,
+          duration: 0,
+          isAvailable: true,
+        },
+        {
+          vehicleTypeName: "ATV",
+          price: 0,
+          duration: 45,
+          isAvailable: true,
+        },
+      ],
+    });
+
+    await t.finishInProgressScheduledFunctions();
+
+    const service = await asAdmin.query(api.services.getById, { serviceId });
+    expect(
+      service?.vehiclePrices.map((row) => ({
+        name: row.vehicleType?.name,
+        price: row.price,
+        duration: row.duration,
+        available: row.isAvailable,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        { name: "Car", price: 125, duration: 90, available: true },
+        { name: "RV", price: 250, duration: 0, available: false },
+        { name: "ATV", price: 0, duration: 45, available: false },
+      ]),
+    );
+  });
+
   test("landing page pricing is curated and grouped by vehicle type", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/services.ts
+++ b/convex/services.ts
@@ -47,6 +47,7 @@ function assertHasPositivePrice(args: {
   basePrice?: number;
   vehiclePrices?: Array<{
     price: number;
+    duration?: number;
     isAvailable: boolean;
   }>;
 }) {
@@ -189,7 +190,7 @@ async function getServiceVehiclePricesForPresentation(
         vehicleTypeId: vehicleType._id,
         price,
         duration: service.duration,
-        isAvailable: price > 0,
+        isAvailable: price > 0 && service.duration > 0,
         createdAt: service._creationTime,
         updatedAt: service._creationTime,
         vehicleType,
@@ -275,13 +276,16 @@ async function replaceServiceVehiclePrices(
     const vehicleType = await ensureVehicleTypeForPrice(ctx, input);
     if (!vehicleType || seen.has(vehicleType._id)) continue;
     seen.add(vehicleType._id);
+    const price = Math.max(0, input.price || 0);
+    const duration = Math.max(0, Math.floor(input.duration || 0));
+    const isAvailable = input.isAvailable && price > 0 && duration > 0;
 
     const rowId = await ctx.db.insert("serviceVehiclePrices", {
       serviceId,
       vehicleTypeId: vehicleType._id,
-      price: Math.max(0, input.price || 0),
-      duration: Math.max(0, Math.floor(input.duration || 0)),
-      isAvailable: input.isAvailable,
+      price,
+      duration,
+      isAvailable,
       createdAt: now,
       updatedAt: now,
     });

--- a/convex/vehicleTypes.test.ts
+++ b/convex/vehicleTypes.test.ts
@@ -7,6 +7,9 @@ import { modules, stripeFetchMock } from "./test.setup";
 describe("vehicleTypes", () => {
   afterEach(() => {
     vi.stubGlobal("fetch", vi.fn(stripeFetchMock));
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.GEMINI_VEHICLE_CLASSIFIER_MODEL;
   });
 
   test("seeds default vehicle types", async () => {
@@ -224,6 +227,94 @@ describe("vehicleTypes", () => {
     expect(result.legacySize).toBe("large");
     expect(result.source).toBe("vpic");
     expect(result.confidence).toBe("high");
+    expect(result.needsAdminReview).toBe(false);
+  });
+
+  test("matches vPIC models when drivetrain suffixes differ", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const urlString = String(url);
+        if (urlString.includes("fueleconomy.gov")) {
+          return Response.json({}, { status: 500 });
+        }
+        if (urlString.includes("vpic.nhtsa.dot.gov")) {
+          return Response.json({
+            Results: [
+              {
+                Model_Name: "Sorento",
+                VehicleTypeName: "Sport Utility Vehicle",
+              },
+            ],
+          });
+        }
+        return Response.json({}, { status: 404 });
+      }),
+    );
+
+    const result = await t.action(api.vehicleTypes.classify, {
+      year: 2012,
+      make: "Kia",
+      model: "Sorento AWD",
+    });
+
+    expect(result.vehicleTypeName).toBe("SUV");
+    expect(result.legacySize).toBe("large");
+    expect(result.source).toBe("vpic");
+    expect(result.needsAdminReview).toBe(false);
+  });
+
+  test("uses Gemini Search as a final classifier for oddball manual vehicles", async () => {
+    const t = convexTest(schema, modules);
+    process.env.GEMINI_API_KEY = "gemini_test_key";
+    process.env.GEMINI_VEHICLE_CLASSIFIER_MODEL = "gemini-test-model";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, options?: RequestInit) => {
+        const urlString = String(url);
+        if (urlString.includes("fueleconomy.gov")) {
+          return Response.json({}, { status: 500 });
+        }
+        if (urlString.includes("vpic.nhtsa.dot.gov")) {
+          return Response.json({ Results: [] });
+        }
+        if (urlString.includes("generativelanguage.googleapis.com")) {
+          expect(options?.body?.toString()).toContain("google_search");
+          return Response.json({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      text: JSON.stringify({
+                        slug: "motorcycle",
+                        confidence: "high",
+                        rawCategory: "three-wheeled motorcycle / roadster",
+                      }),
+                    },
+                  ],
+                },
+              },
+            ],
+          });
+        }
+        return Response.json({}, { status: 404 });
+      }),
+    );
+
+    const result = await t.action(api.vehicleTypes.classify, {
+      year: 2024,
+      make: "Can-Am",
+      model: "Spyder RT",
+    });
+
+    expect(result.vehicleTypeName).toBe("Motorcycle");
+    expect(result.legacySize).toBe("small");
+    expect(result.confidence).toBe("high");
+    expect(result.rawCategory).toContain("Gemini Search");
     expect(result.needsAdminReview).toBe(false);
   });
 

--- a/convex/vehicleTypes.ts
+++ b/convex/vehicleTypes.ts
@@ -217,6 +217,26 @@ function mapCategoryToSlug(value: string | undefined): {
 } {
   const normalized = value?.toLowerCase() ?? "";
   if (!normalized) return { slug: "car", confidence: "low" };
+  if (
+    normalized.includes("recreational vehicle") ||
+    normalized.includes("motorhome") ||
+    normalized.includes("rv")
+  ) {
+    return { slug: "van", confidence: "medium" };
+  }
+  if (
+    normalized.includes("atv") ||
+    normalized.includes("all-terrain") ||
+    normalized.includes("all terrain") ||
+    normalized.includes("side-by-side") ||
+    normalized.includes("side by side") ||
+    normalized.includes("utv") ||
+    normalized.includes("can-am") ||
+    normalized.includes("spyder") ||
+    normalized.includes("slingshot")
+  ) {
+    return { slug: "motorcycle", confidence: "medium" };
+  }
   if (normalized.includes("minivan") || normalized.includes("van")) {
     return { slug: "van", confidence: "high" };
   }
@@ -242,6 +262,118 @@ function mapCategoryToSlug(value: string | undefined): {
     return { slug: "van", confidence: "medium" };
   }
   return { slug: "car", confidence: "low" };
+}
+
+function normalizeModelName(value: string | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/\b(all[-\s]?wheel|four[-\s]?wheel|front[-\s]?wheel|rear[-\s]?wheel)\s+drive\b/g, " ")
+    .replace(/\b(awd|4wd|2wd|fwd|rwd|4x4|2x4)\b/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function isModelMatch(inputModel: string, candidateModel: string): boolean {
+  const input = normalizeModelName(inputModel);
+  const candidate = normalizeModelName(candidateModel);
+  if (!input || !candidate) return false;
+  return candidate.includes(input) || input.includes(candidate);
+}
+
+function getGeminiApiKey(): string | undefined {
+  return (
+    process.env.GEMINI_API_KEY ||
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY
+  )?.trim();
+}
+
+async function classifyWithGeminiSearch(args: {
+  year: number;
+  make: string;
+  model: string;
+}): Promise<{
+  slug: string;
+  confidence: "high" | "medium" | "low";
+  rawCategory?: string;
+} | null> {
+  const apiKey = getGeminiApiKey();
+  if (!apiKey) return null;
+
+  const model = process.env.GEMINI_VEHICLE_CLASSIFIER_MODEL || "gemini-2.5-flash";
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": apiKey,
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                text:
+                  "Use Google Search if needed. Classify this vehicle for a mobile detailing pricing engine. " +
+                  "Return only compact JSON with keys slug, confidence, rawCategory. " +
+                  "slug must be one of car, truck, suv, van, motorcycle. " +
+                  "Use motorcycle for motorcycles, scooters, trikes, ATVs, UTVs, side-by-sides, Can-Am Spyder/Ryker, and Polaris Slingshot. " +
+                  "Use van for RVs/motorhomes/campers if no better category exists. " +
+                  "Use confidence high only when the category is clear, medium when likely, low when uncertain. " +
+                  `Vehicle: ${args.year} ${args.make} ${args.model}`,
+              },
+            ],
+          },
+        ],
+        tools: [{ google_search: {} }],
+        generationConfig: {
+          temperature: 0,
+          responseMimeType: "application/json",
+        },
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Gemini vehicle classification failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const text = String(
+    data?.candidates?.[0]?.content?.parts
+      ?.map((part: any) => part?.text ?? "")
+      .join("") ?? "",
+  ).trim();
+  if (!text) return null;
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    parsed = JSON.parse(jsonMatch[0]);
+  }
+
+  const mapped = mapCategoryToSlug(
+    `${parsed?.slug ?? ""} ${parsed?.rawCategory ?? ""}`,
+  );
+  const confidence =
+    parsed?.confidence === "high" || parsed?.confidence === "medium"
+      ? parsed.confidence
+      : mapped.confidence;
+
+  return {
+    slug:
+      ["car", "truck", "suv", "van", "motorcycle"].includes(parsed?.slug)
+        ? parsed.slug
+        : mapped.slug,
+    confidence,
+    rawCategory: parsed?.rawCategory
+      ? `Gemini Search: ${String(parsed.rawCategory)}`
+      : "Gemini Search classification",
+  };
 }
 
 async function fetchJson(url: string) {
@@ -490,9 +622,7 @@ export const classify = action({
           `https://vpic.nhtsa.dot.gov/api/vehicles/GetModelsForMakeYear/make/${make}/modelyear/${args.year}?format=json`,
         );
         const match = (vpic?.Results ?? []).find((result: any) =>
-          String(result.Model_Name ?? "")
-            .toLowerCase()
-            .includes(args.model.trim().toLowerCase()),
+          isModelMatch(args.model, String(result.Model_Name ?? "")),
         );
         rawCategory = match?.VehicleTypeName ?? match?.Model_Name ?? rawCategory;
         const vpicMapped = mapCategoryToSlug(rawCategory);
@@ -502,6 +632,26 @@ export const classify = action({
         }
       } catch {
         // Keep fallback.
+      }
+    }
+
+    if (mapped.confidence === "low") {
+      try {
+        const geminiMapped = await classifyWithGeminiSearch(args);
+        if (
+          geminiMapped &&
+          (geminiMapped.confidence === "high" ||
+            geminiMapped.confidence === "medium")
+        ) {
+          mapped = {
+            slug: geminiMapped.slug,
+            confidence: geminiMapped.confidence,
+          };
+          source = "fallback";
+          rawCategory = geminiMapped.rawCategory ?? rawCategory;
+        }
+      } catch {
+        // Keep low-confidence manual review fallback if Gemini is unavailable.
       }
     }
 


### PR DESCRIPTION
## Summary

- adds a manual vehicle entry path that still asks the backend to classify oddball vehicles before requiring admin review
- adds a Gemini Search fallback for low-confidence vehicle classification when GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY is configured
- hides service pricing rows unless that vehicle type has both price and duration configured

## Implementation Notes

- normalized drivetrain suffixes for vPIC model matching so examples like Kia Sorento AWD can match the base Sorento model
- kept Gemini classification server-side in Convex through the Gemini REST API with google_search enabled
- made auto-created admin vehicle price rows unavailable until price and minutes are set

## Testing Notes

- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test:once
- pnpm build

Closes #91