### PR TITLE
fix: stabilize booking photo uploads and cleanup booking flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the River City Mobile Detailing project are documented in
 
 ---
 
+## [v1.0.1] - 2026-06-15
+### Added
+- **R2 Upload Relay Route**: Added `/api/r2-upload-relay` to relay photo uploads to R2 to avoid client CORS/connection errors.
+- **UTV/Side-by-side Classification**: Implemented classification rule for UTV/side-by-side vehicle models (e.g., Can-Am Defender, Maverick) and added unit tests.
+
+### Fixed
+- **Upload Failover**: Configured `VehicleLookupCard` to fall back to the relay upload route if direct signed URL upload fails.
+- **Booking Flow State Cleanup**: Fully reset forms (including active services, expanded index settings) and cleared local storage keys (`booking-storage`, `selectedAddress`, `appointmentFormData`) when resetting/cancelling the booking flow.
+
+---
+
 ## [v1.0.0] - 2026-06-13
 ### Added
 - **Coupon Dashboard**: Built a coupons administration panel (`/admin/coupons`) with stats summaries (total coupons, active coupons, and total redemptions) and a dialog to create/delete coupons on Stripe.

--- a/app/api/r2-upload-relay/route.ts
+++ b/app/api/r2-upload-relay/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const MAX_RELAY_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+function isAllowedR2UploadUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname.endsWith(".r2.cloudflarestorage.com")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const uploadUrl = request.headers.get("x-r2-upload-url");
+  const contentType = request.headers.get("content-type") || "application/octet-stream";
+  const contentLength = Number(request.headers.get("content-length") || 0);
+
+  if (!uploadUrl || !isAllowedR2UploadUrl(uploadUrl)) {
+    return NextResponse.json({ error: "Invalid upload target." }, { status: 400 });
+  }
+
+  if (contentLength > MAX_RELAY_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "Photo is too large to relay. Please use a photo under 10MB." },
+      { status: 413 },
+    );
+  }
+
+  const body = await request.arrayBuffer();
+  if (body.byteLength > MAX_RELAY_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "Photo is too large to relay. Please use a photo under 10MB." },
+      { status: 413 },
+    );
+  }
+
+  const uploadResponse = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body,
+  });
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text();
+    return NextResponse.json(
+      {
+        error:
+          errorText ||
+          `Storage upload failed with status ${uploadResponse.status}.`,
+      },
+      { status: uploadResponse.status || 502 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/booking/booking-flow.tsx
+++ b/components/booking/booking-flow.tsx
@@ -913,9 +913,50 @@ export default function BookingFlow() {
 
   const handleCancel = () => {
     resetBooking();
+    step1Form.reset({
+      scheduledDate: undefined,
+      scheduledTime: "",
+      street: "",
+      city: "",
+      state: "",
+      zip: "",
+      locationNotes: "",
+      latitude: undefined,
+      longitude: undefined,
+    });
+    step2Form.reset({
+      name: "",
+      phone: "",
+      email: "",
+      smsOptIn: true,
+    });
+    step3Form.reset({
+      vehicles: [
+        {
+          year: "",
+          make: "",
+          model: "",
+          color: "",
+          licensePlate: "",
+          size: "small",
+          hasPet: false,
+          beforePhotos: [],
+        },
+      ],
+    });
+    step4Form.reset({
+      serviceIds: [],
+      vehicleServices: {},
+    });
+    setTravelQuote(null);
+    setOutOfAreaMode("idle");
+    setExpandedVehicleIndex(0);
+    setExpandedStep4VehicleIndex(0);
+    setActiveServiceSection({});
     if (typeof window !== "undefined") {
       localStorage.removeItem("selectedAddress");
       localStorage.removeItem("appointmentFormData");
+      localStorage.removeItem("booking-storage");
     }
     router.push("/");
   };

--- a/components/forms/vehicle-lookup-card.tsx
+++ b/components/forms/vehicle-lookup-card.tsx
@@ -181,6 +181,47 @@ function uploadPhotoToSignedUrl(args: {
   });
 }
 
+async function relayPhotoToSignedUrl(args: {
+  url: string;
+  file: File;
+  contentType: string;
+}) {
+  const response = await fetch("/api/r2-upload-relay", {
+    method: "PUT",
+    headers: {
+      "Content-Type": args.contentType,
+      "x-r2-upload-url": args.url,
+    },
+    body: args.file,
+  });
+
+  if (!response.ok) {
+    let message = "Photo upload failed. Please try again or continue without photos.";
+    try {
+      const result = await response.clone().json();
+      if (typeof result?.error === "string" && result.error.trim()) {
+        message = result.error;
+      }
+    } catch {
+      const text = await response.text();
+      if (text.trim()) message = text;
+    }
+    throw new Error(message);
+  }
+}
+
+async function uploadPhoto(args: {
+  url: string;
+  file: File;
+  contentType: string;
+}) {
+  try {
+    await uploadPhotoToSignedUrl(args);
+  } catch {
+    await relayPhotoToSignedUrl(args);
+  }
+}
+
 export function VehicleLookupCard({
   value,
   onChange,
@@ -387,7 +428,7 @@ export function VehicleLookupCard({
           fileName: file.name,
           contentType,
         });
-        await uploadPhotoToSignedUrl({ url: upload.url, file, contentType });
+        await uploadPhoto({ url: upload.url, file, contentType });
         uploadedPhotos.push({
           key: upload.key,
           fileName: file.name,

--- a/convex/vehicleTypes.test.ts
+++ b/convex/vehicleTypes.test.ts
@@ -266,6 +266,56 @@ describe("vehicleTypes", () => {
     expect(result.needsAdminReview).toBe(false);
   });
 
+  test("routes Can-Am UTVs to a configured side-by-side vehicle type", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("vehicleTypes", {
+        name: "Side-by-side",
+        slug: "side-by-side",
+        legacySize: "medium",
+        apiAliases: ["side-by-side", "utv"],
+        isActive: true,
+        displayOrder: 90,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const urlString = String(url);
+        if (urlString.includes("fueleconomy.gov")) {
+          return Response.json({}, { status: 500 });
+        }
+        if (urlString.includes("vpic.nhtsa.dot.gov")) {
+          return Response.json({
+            Results: [
+              {
+                Model_Name: "Defender",
+                VehicleTypeName: "Utility Terrain Vehicle",
+              },
+            ],
+          });
+        }
+        return Response.json({}, { status: 404 });
+      }),
+    );
+
+    const result = await t.action(api.vehicleTypes.classify, {
+      year: 2014,
+      make: "Can-Am",
+      model: "Defender",
+    });
+
+    expect(result.vehicleTypeName).toBe("Side-by-side");
+    expect(result.legacySize).toBe("medium");
+    expect(result.source).toBe("vpic");
+    expect(result.confidence).toBe("medium");
+    expect(result.needsAdminReview).toBe(false);
+  });
+
   test("uses Gemini Search as a final classifier for oddball manual vehicles", async () => {
     const t = convexTest(schema, modules);
     process.env.GEMINI_API_KEY = "gemini_test_key";

--- a/convex/vehicleTypes.ts
+++ b/convex/vehicleTypes.ts
@@ -231,10 +231,15 @@ function mapCategoryToSlug(value: string | undefined): {
     normalized.includes("side-by-side") ||
     normalized.includes("side by side") ||
     normalized.includes("utv") ||
+    normalized.includes("utility terrain") ||
+    normalized.includes("defender") ||
+    normalized.includes("maverick") ||
     normalized.includes("can-am") ||
-    normalized.includes("spyder") ||
     normalized.includes("slingshot")
   ) {
+    return { slug: "side-by-side", confidence: "medium" };
+  }
+  if (normalized.includes("spyder") || normalized.includes("ryker")) {
     return { slug: "motorcycle", confidence: "medium" };
   }
   if (normalized.includes("minivan") || normalized.includes("van")) {
@@ -318,8 +323,9 @@ async function classifyWithGeminiSearch(args: {
                 text:
                   "Use Google Search if needed. Classify this vehicle for a mobile detailing pricing engine. " +
                   "Return only compact JSON with keys slug, confidence, rawCategory. " +
-                  "slug must be one of car, truck, suv, van, motorcycle. " +
-                  "Use motorcycle for motorcycles, scooters, trikes, ATVs, UTVs, side-by-sides, Can-Am Spyder/Ryker, and Polaris Slingshot. " +
+                  "slug must be one of car, truck, suv, van, motorcycle, side-by-side. " +
+                  "Use side-by-side for ATVs, UTVs, side-by-sides, Can-Am Defender/Maverick, Polaris RZR/Ranger, and similar off-road utility vehicles. " +
+                  "Use motorcycle for motorcycles, scooters, trikes, Can-Am Spyder/Ryker, and road-going three-wheel motorcycles. " +
                   "Use van for RVs/motorhomes/campers if no better category exists. " +
                   "Use confidence high only when the category is clear, medium when likely, low when uncertain. " +
                   `Vehicle: ${args.year} ${args.make} ${args.model}`,
@@ -366,7 +372,7 @@ async function classifyWithGeminiSearch(args: {
 
   return {
     slug:
-      ["car", "truck", "suv", "van", "motorcycle"].includes(parsed?.slug)
+      ["car", "truck", "suv", "van", "motorcycle", "side-by-side"].includes(parsed?.slug)
         ? parsed.slug
         : mapped.slug,
     confidence,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivercitymd",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",


### PR DESCRIPTION
## Summary
This PR stabilizes booking before-photo uploads by providing an upload relay route failover, resets booking flow state properly on cancel/reset, and improves UTV/side-by-side vehicle type classification.

## Implementation Notes
- Created Next.js API route `/api/r2-upload-relay` to bypass CORS issues by relaying files up to 10MB to R2 signed URLs.
- Updated `VehicleLookupCard` to catch errors on direct upload to R2 signed URLs and fall back to using the new relay endpoint.
- Updated `BookingFlow` cancel action (`handleCancel`) to reset step forms and clear all relevant localStorage values (`booking-storage`, `selectedAddress`, `appointmentFormData`).
- Expanded the vehicle classifier in `convex/vehicleTypes.ts` to map UTVs/side-by-sides (such as Can-Am models) to the `side-by-side` slug instead of routing them to `motorcycle`.
- Added unit tests for side-by-side vehicle type classification in `convex/vehicleTypes.test.ts`.

## Testing Notes
- Verified that all unit tests pass locally: `pnpm test:once`
- Checked that eslint/linter reports no errors: `pnpm lint`
- Confirmed Next.js production build succeeds: `pnpm build`

Closes #95