### PR TITLE
fix: make r2 upload relay route public in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the River City Mobile Detailing project are documented in
 
 ---
 
+## [v1.0.2] - 2026-06-15
+### Fixed
+- **Relay Upload CORS**: Configured the `/api/r2-upload-relay` route as a public route in Clerk middleware (`proxy.ts`). This resolves the CORS issue when unauthenticated guest users try to upload booking photos.
+
+---
+
 ## [v1.0.1] - 2026-06-15
 ### Added
 - **R2 Upload Relay Route**: Added `/api/r2-upload-relay` to relay photo uploads to R2 to avoid client CORS/connection errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivercitymd",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,6 +9,7 @@ const isPublicRoute = createRouteMatcher([
   "/booking(.*)",
   "/sign-in(.*)",
   "/sign-up(.*)",
+  "/api/r2-upload-relay",
 ]);
 
 const isOnboardingRoute = createRouteMatcher(["/onboarding(.*)"]);


### PR DESCRIPTION
## Summary
This PR fixes the CORS preflight issue during photo uploads by making the R2 upload relay API route `/api/r2-upload-relay` public in the Clerk middleware config (`proxy.ts`).

## Implementation Notes
- Added `"/api/r2-upload-relay"` to the list of public routes (`isPublicRoute`) in `proxy.ts`. This allows unauthenticated guest users on the booking page to upload photos via the relay route without being redirected to Clerk's sign-in page.

## Testing Notes
- Verified all tests pass: `pnpm test:once`
- Checked build and lint pass successfully: `pnpm lint && pnpm build`

Closes #95