### PR TITLE
feat: support adding multiple vehicles for clients in admin appointment edit and customer detail views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the River City Mobile Detailing project are documented in
 
 ---
 
+## [v1.0.3] - 2026-06-16
+### Added
+- **Multi-Vehicle Customer Management**: Added a dialog/form to the admin Customer Detail page to register new vehicles directly to a customer's profile.
+- **Inline Vehicle Creation in Edit Appointment**: Added a sub-form to add new vehicles directly when editing an appointment, automatically selecting the newly created vehicle for the appointment and updating the pricing breakdown.
+
+---
+
 ## [v1.0.2] - 2026-06-15
 ### Fixed
 - **Relay Upload CORS**: Configured the `/api/r2-upload-relay` route as a public route in Clerk middleware (`proxy.ts`). This resolves the CORS issue when unauthenticated guest users try to upload booking photos.

--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -47,6 +47,7 @@ import {
   X,
   Images,
   Tag,
+  Plus,
 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -127,6 +128,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
   const updateAppointment = useMutation(api.appointments.update);
   const applyWorkAdjustment = useMutation(api.appointments.applyWorkAdjustment);
   const updateVehicle = useMutation(api.vehicles.updateVehicle);
+  const createVehicle = useMutation(api.vehicles.create);
   const updateBillingSettings = useMutation(api.invoices.updateBillingSettings);
   const reissueStripeInvoice = useAction(api.payments.reissueStripeInvoice);
   const applyCouponToInvoice = useAction(api.payments.applyCouponToInvoice);
@@ -212,6 +214,70 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
   const [editVehicleSizes, setEditVehicleSizes] = useState<Record<string, string>>({});
   const [editVehicleTypeIds, setEditVehicleTypeIds] = useState<Record<string, string>>({});
   const [editPetFeeVehicleIds, setEditPetFeeVehicleIds] = useState<Id<"vehicles">[]>([]);
+  const [isCreatingVehicle, setIsCreatingVehicle] = useState(false);
+  const [newVehicle, setNewVehicle] = useState({
+    year: "",
+    make: "",
+    model: "",
+    color: "",
+    size: "medium" as "small" | "medium" | "large",
+    licensePlate: "",
+    notes: "",
+  });
+
+  const resetVehicleForm = () => {
+    setNewVehicle({
+      year: "",
+      make: "",
+      model: "",
+      color: "",
+      size: "medium",
+      licensePlate: "",
+      notes: "",
+    });
+  };
+
+  const handleCreateVehicle = async () => {
+    if (!data?.userId) return;
+    if (!newVehicle.year || !newVehicle.make.trim() || !newVehicle.model.trim()) {
+      toast.error("Vehicle year, make, and model are required");
+      return;
+    }
+
+    setIsCreatingVehicle(true);
+    try {
+      const vehicleId = await createVehicle({
+        userId: data.userId,
+        year: Number(newVehicle.year),
+        make: newVehicle.make.trim(),
+        model: newVehicle.model.trim(),
+        size: newVehicle.size,
+        color: newVehicle.color.trim() || undefined,
+        licensePlate: newVehicle.licensePlate.trim() || undefined,
+        notes: newVehicle.notes.trim() || undefined,
+      });
+
+      // Automatically check/select this vehicle
+      setEditVehicleIds((prev) => [...prev, vehicleId]);
+
+      // Pre-set sizes/types mapping
+      setEditVehicleSizes((prev) => ({
+        ...prev,
+        [vehicleId]: newVehicle.size,
+      }));
+      setEditVehicleTypeIds((prev) => ({
+        ...prev,
+        [vehicleId]: "",
+      }));
+
+      resetVehicleForm();
+      toast.success("Vehicle added and selected");
+    } catch {
+      toast.error("Failed to add vehicle");
+    } finally {
+      setIsCreatingVehicle(false);
+    }
+  };
   const [adjustingWork, setAdjustingWork] = useState(false);
   const [adjustVehicleIds, setAdjustVehicleIds] = useState<Id<"vehicles">[]>([]);
   const [adjustServiceIds, setAdjustServiceIds] = useState<Id<"services">[]>([]);
@@ -762,76 +828,212 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                 <p className="text-sm text-muted-foreground">
                   Loading customer vehicles...
                 </p>
-              ) : customerVehicles.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  This customer has no saved vehicles yet.
-                </p>
               ) : (
-                <div className="space-y-3">
-                  {customerVehicles.map((v) => {
-                    const checked = editVehicleIds.includes(v._id);
-                    const hasPetFee = editPetFeeVehicleIds.includes(v._id);
-                    return (
-                      <div
-                        key={v._id}
-                        className="rounded-md border p-3"
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="flex items-start gap-3">
-                            <Checkbox
-                              checked={checked}
-                              onCheckedChange={(value) =>
-                                toggleVehicle(v._id, value === true)
-                              }
-                              className="mt-1"
-                            />
-                            <div>
-                              <p className="font-medium text-sm">
-                                {v.year} {v.make} {v.model}
-                              </p>
-                              <div className="flex gap-2 text-xs text-muted-foreground">
-                                {v.color && <span>{v.color}</span>}
-                                {v.licensePlate && <span>{v.licensePlate}</span>}
+                <div className="space-y-4">
+                  {customerVehicles.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      This customer has no saved vehicles yet.
+                    </p>
+                  ) : (
+                    <div className="space-y-3">
+                      {customerVehicles.map((v) => {
+                        const checked = editVehicleIds.includes(v._id);
+                        const hasPetFee = editPetFeeVehicleIds.includes(v._id);
+                        return (
+                          <div
+                            key={v._id}
+                            className="rounded-md border p-3"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="flex items-start gap-3">
+                                <Checkbox
+                                  checked={checked}
+                                  onCheckedChange={(value) =>
+                                    toggleVehicle(v._id, value === true)
+                                  }
+                                  className="mt-1"
+                                />
+                                <div>
+                                  <p className="font-medium text-sm">
+                                    {v.year} {v.make} {v.model}
+                                  </p>
+                                  <div className="flex gap-2 text-xs text-muted-foreground">
+                                    {v.color && <span>{v.color}</span>}
+                                    {v.licensePlate && <span>{v.licensePlate}</span>}
+                                  </div>
+                                </div>
                               </div>
+                              <Select
+                                value={editVehicleTypeIds[v._id] || "__legacy__"}
+                                onValueChange={(val) =>
+                                  setEditVehicleTypeIds((prev) => ({
+                                    ...prev,
+                                    [v._id]: val === "__legacy__" ? "" : val,
+                                  }))
+                                }
+                                disabled={!checked || typedVehicleTypes.length === 0}
+                              >
+                                <SelectTrigger className="w-36">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="__legacy__">
+                                    {v.size || "medium"}
+                                  </SelectItem>
+                                  {typedVehicleTypes.map((vehicleType) => (
+                                    <SelectItem key={vehicleType._id} value={vehicleType._id}>
+                                      {vehicleType.name}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            <div className="mt-3 flex items-center gap-2 border-t pt-3">
+                              <Checkbox
+                                checked={hasPetFee}
+                                onCheckedChange={(value) =>
+                                  togglePetFeeVehicle(v._id, value === true)
+                                }
+                              />
+                              <Label className="text-xs font-normal">Pet fee</Label>
                             </div>
                           </div>
-                          <Select
-                            value={editVehicleTypeIds[v._id] || "__legacy__"}
-                            onValueChange={(val) =>
-                              setEditVehicleTypeIds((prev) => ({
-                                ...prev,
-                                [v._id]: val === "__legacy__" ? "" : val,
-                              }))
-                            }
-                            disabled={!checked || typedVehicleTypes.length === 0}
-                          >
-                            <SelectTrigger className="w-36">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="__legacy__">
-                                {v.size || "medium"}
-                              </SelectItem>
-                              {typedVehicleTypes.map((vehicleType) => (
-                                <SelectItem key={vehicleType._id} value={vehicleType._id}>
-                                  {vehicleType.name}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div className="mt-3 flex items-center gap-2 border-t pt-3">
-                          <Checkbox
-                            checked={hasPetFee}
-                            onCheckedChange={(value) =>
-                              togglePetFeeVehicle(v._id, value === true)
-                            }
-                          />
-                          
-                        </div>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {/* Add Vehicle sub-form */}
+                  <div className="space-y-4 rounded-lg border p-4 mt-4 bg-muted/20">
+                    <div className="flex items-center gap-2">
+                      <Plus className="h-4 w-4" />
+                      <div>
+                        <p className="text-sm font-medium">Add vehicle for this customer</p>
+                        <p className="text-xs text-muted-foreground">
+                          New vehicles are saved immediately and automatically selected.
+                        </p>
                       </div>
-                    );
-                  })}
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1">
+                        <Label htmlFor="new-v-year" className="text-xs">Year</Label>
+                        <Input
+                          id="new-v-year"
+                          type="number"
+                          placeholder="2024"
+                          className="h-8 text-xs"
+                          value={newVehicle.year}
+                          onChange={(e) =>
+                            setNewVehicle((prev) => ({ ...prev, year: e.target.value }))
+                          }
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <Label htmlFor="new-v-make" className="text-xs">Make</Label>
+                        <Input
+                          id="new-v-make"
+                          placeholder="Toyota"
+                          className="h-8 text-xs"
+                          value={newVehicle.make}
+                          onChange={(e) =>
+                            setNewVehicle((prev) => ({ ...prev, make: e.target.value }))
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1">
+                        <Label htmlFor="new-v-model" className="text-xs">Model</Label>
+                        <Input
+                          id="new-v-model"
+                          placeholder="Camry"
+                          className="h-8 text-xs"
+                          value={newVehicle.model}
+                          onChange={(e) =>
+                            setNewVehicle((prev) => ({ ...prev, model: e.target.value }))
+                          }
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <Label htmlFor="new-v-color" className="text-xs">Color</Label>
+                        <Input
+                          id="new-v-color"
+                          placeholder="Silver"
+                          className="h-8 text-xs"
+                          value={newVehicle.color}
+                          onChange={(e) =>
+                            setNewVehicle((prev) => ({ ...prev, color: e.target.value }))
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1">
+                        <Label htmlFor="new-v-size" className="text-xs">Size</Label>
+                        <Select
+                          value={newVehicle.size}
+                          onValueChange={(val) =>
+                            setNewVehicle((prev) => ({
+                              ...prev,
+                              size: val as "small" | "medium" | "large",
+                            }))
+                          }
+                        >
+                          <SelectTrigger id="new-v-size" className="h-8 text-xs">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="small">Small</SelectItem>
+                            <SelectItem value="medium">Medium</SelectItem>
+                            <SelectItem value="large">Large</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-1">
+                        <Label htmlFor="new-v-license" className="text-xs">License Plate</Label>
+                        <Input
+                          id="new-v-license"
+                          placeholder="ABC-123"
+                          className="h-8 text-xs"
+                          value={newVehicle.licensePlate}
+                          onChange={(e) =>
+                            setNewVehicle((prev) => ({
+                              ...prev,
+                              licensePlate: e.target.value,
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <div className="space-y-1">
+                      <Label htmlFor="new-v-notes" className="text-xs">Notes</Label>
+                      <Textarea
+                        id="new-v-notes"
+                        placeholder="Optional notes"
+                        className="min-h-[50px] text-xs p-2"
+                        value={newVehicle.notes}
+                        onChange={(e) =>
+                          setNewVehicle((prev) => ({ ...prev, notes: e.target.value }))
+                        }
+                      />
+                    </div>
+
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={handleCreateVehicle}
+                        disabled={isCreatingVehicle || !newVehicle.year || !newVehicle.make || !newVehicle.model}
+                      >
+                        {isCreatingVehicle ? "Saving..." : "Save Vehicle"}
+                      </Button>
+                    </div>
+                  </div>
                 </div>
               )
             ) : vehicles.length === 0 ? (

--- a/components/admin/customer-detail-client.tsx
+++ b/components/admin/customer-detail-client.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import {
@@ -26,6 +26,7 @@ import {
   FileText,
   AlertCircle,
   Pencil,
+  Plus,
 } from "lucide-react";
 import Link from "next/link";
 import {
@@ -38,6 +39,24 @@ import {
 } from "@/components/ui/table";
 import { formatTime12h } from "@/lib/time";
 import { EditCustomerForm } from "@/components/forms";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 type Props = {
   customerId: Id<"users">;
@@ -47,6 +66,60 @@ export default function CustomerDetailClient({ customerId }: Props) {
   const router = useRouter();
   const customerData = useQuery(api.users.getByIdWithDetails, { userId: customerId });
   const [showEditForm, setShowEditForm] = useState(false);
+  const [showAddVehicleForm, setShowAddVehicleForm] = useState(false);
+  const [newVehicle, setNewVehicle] = useState({
+    year: "",
+    make: "",
+    model: "",
+    size: "medium" as "small" | "medium" | "large",
+    color: "",
+    licensePlate: "",
+    notes: "",
+  });
+  const [isCreatingVehicle, setIsCreatingVehicle] = useState(false);
+  const createVehicle = useMutation(api.vehicles.create);
+
+  const resetVehicleForm = () => {
+    setNewVehicle({
+      year: "",
+      make: "",
+      model: "",
+      size: "medium",
+      color: "",
+      licensePlate: "",
+      notes: "",
+    });
+  };
+
+  const handleCreateVehicle = async () => {
+    if (!newVehicle.year || !newVehicle.make.trim() || !newVehicle.model.trim()) {
+      toast.error("Vehicle year, make, and model are required");
+      return;
+    }
+
+    setIsCreatingVehicle(true);
+    try {
+      await createVehicle({
+        userId: customerId,
+        year: Number(newVehicle.year),
+        make: newVehicle.make.trim(),
+        model: newVehicle.model.trim(),
+        size: newVehicle.size,
+        color: newVehicle.color.trim() || undefined,
+        licensePlate: newVehicle.licensePlate.trim() || undefined,
+        notes: newVehicle.notes.trim() || undefined,
+      });
+
+      toast.success("Vehicle added successfully");
+      resetVehicleForm();
+      setShowAddVehicleForm(false);
+      router.refresh();
+    } catch {
+      toast.error("Failed to add vehicle");
+    } finally {
+      setIsCreatingVehicle(false);
+    }
+  };
 
   if (customerData === undefined) {
     return (
@@ -341,9 +414,15 @@ export default function CustomerDetailClient({ customerId }: Props) {
 
       {/* Vehicles */}
       <Card>
-        <CardHeader>
-          <CardTitle>Vehicles ({vehicles.length})</CardTitle>
-          <CardDescription>All vehicles registered to this customer</CardDescription>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle>Vehicles ({vehicles.length})</CardTitle>
+            <CardDescription>All vehicles registered to this customer</CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => setShowAddVehicleForm(true)}>
+            <Plus className="w-4 h-4 mr-2" />
+            Add Vehicle
+          </Button>
         </CardHeader>
         <CardContent>
           {vehicles.length === 0 ? (
@@ -384,6 +463,121 @@ export default function CustomerDetailClient({ customerId }: Props) {
         onOpenChange={setShowEditForm}
         customer={user}
       />
+
+      <Dialog open={showAddVehicleForm} onOpenChange={setShowAddVehicleForm}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>Add New Vehicle</DialogTitle>
+            <DialogDescription>
+              Enter vehicle details to add to this customer&apos;s profile
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="vehicle-year">Year</Label>
+                <Input
+                  id="vehicle-year"
+                  type="number"
+                  placeholder="2024"
+                  value={newVehicle.year}
+                  onChange={(e) =>
+                    setNewVehicle((prev) => ({ ...prev, year: e.target.value }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="vehicle-make">Make</Label>
+                <Input
+                  id="vehicle-make"
+                  placeholder="Toyota"
+                  value={newVehicle.make}
+                  onChange={(e) =>
+                    setNewVehicle((prev) => ({ ...prev, make: e.target.value }))
+                  }
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicle-model">Model</Label>
+              <Input
+                id="vehicle-model"
+                placeholder="Camry"
+                value={newVehicle.model}
+                onChange={(e) =>
+                  setNewVehicle((prev) => ({ ...prev, model: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="vehicle-size">Size</Label>
+                <Select
+                  value={newVehicle.size}
+                  onValueChange={(val) =>
+                    setNewVehicle((prev) => ({
+                      ...prev,
+                      size: val as "small" | "medium" | "large",
+                    }))
+                  }
+                >
+                  <SelectTrigger id="vehicle-size">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="small">Small</SelectItem>
+                    <SelectItem value="medium">Medium</SelectItem>
+                    <SelectItem value="large">Large</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="vehicle-color">Color</Label>
+                <Input
+                  id="vehicle-color"
+                  placeholder="Silver"
+                  value={newVehicle.color}
+                  onChange={(e) =>
+                    setNewVehicle((prev) => ({ ...prev, color: e.target.value }))
+                  }
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicle-license">License Plate</Label>
+              <Input
+                id="vehicle-license"
+                placeholder="ABC-123"
+                value={newVehicle.licensePlate}
+                onChange={(e) =>
+                  setNewVehicle((prev) => ({
+                    ...prev,
+                    licensePlate: e.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vehicle-notes">Notes</Label>
+              <Textarea
+                id="vehicle-notes"
+                placeholder="Any special notes about this vehicle"
+                value={newVehicle.notes}
+                onChange={(e) =>
+                  setNewVehicle((prev) => ({ ...prev, notes: e.target.value }))
+                }
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={handleCreateVehicle}
+              disabled={isCreatingVehicle || !newVehicle.year || !newVehicle.make || !newVehicle.model}
+            >
+              {isCreatingVehicle ? "Adding Vehicle..." : "Add Vehicle"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This Pull Request enables administrators to manage and add multiple vehicles to a client's profile from the admin interface. Specifically, it provides controls to register a new vehicle directly under a customer's profile on the Customer Detail page and inside the Edit Appointment form view (which automatically checks the new vehicle and updates the pricing/invoices).

## Implementation Notes
- **Customer Detail Page (`customer-detail-client.tsx`):**
  - Added an "Add Vehicle" button to the Vehicles card header.
  - Implemented an add-vehicle Dialog modal containing form fields for Year, Make, Model, Size, Color, License Plate, and Notes.
  - Triggers the `api.vehicles.create` mutation on submit and updates the list reactively.
- **Edit Appointment View (`appointment-detail-client.tsx`):**
  - Integrated an inline "Add vehicle for this customer" sub-form when `editing` mode is active.
  - On save, registers the vehicle to the customer, automatically appends it to the checked list (`editVehicleIds`), and updates the form values.
- **Linting & Typings:**
  - Resolved ESLint unescaped quote warning and verified TypeScript build with `tsc --noEmit`.

## Testing Notes
- Executed quality gate checks (`pnpm lint`, `pnpm exec tsc --noEmit`).
- Ran all existing unit and integration test suites via `pnpm test:once` (all 165 tests passed).

Closes #98