### PR TITLE
fix: allow in-progress appointment work adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the River City Mobile Detailing project are documented in
 - **Service Descriptions at Checkout (Dashboard)**: Made services in the customer dashboard appointment booking summary clickable, revealing a Dialog containing complete service descriptions, matching the public booking flow behavior.
 
 ### Fixed
+- **In-Progress Work Adjustments**: Allowed admins to add or remove services on in-progress appointments without failing availability checks for the already-started time slot.
 - **Service Deletion Guidance**: Added a clear hide path for services with appointment history so admins can remove them from new bookings without breaking existing appointment records.
 - **HEIC Image Upload Fallbacks**: Fixed HEIC/HEIF photo uploads being rejected with a "client error" when browser MIME types fallback to `application/octet-stream`. Falls back to parsing filename extensions and maps them to `image/heic`/`image/heif` or relaxes backend verification to match.
 - **Editable Vehicle Mutation**: Expanded `updateVehicle` mutation in `convex/vehicles.ts` to accept optional `year`, `make`, `model`, and `classification` arguments to support fully updating vehicle profiles rather than forcing delete/recreate.

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -155,6 +155,7 @@ describe("appointments", () => {
       asAdmin,
       appointmentId,
       invoiceId,
+      adminId,
       userId,
       vehicleId,
       secondVehicleId,
@@ -670,6 +671,116 @@ describe("appointments", () => {
     expect(appointment?.vehicleIds).toEqual([vehicleId, secondVehicleId]);
     expect(appointment?.totalPrice).toBe(250);
     expect(appointment?.duration).toBe(240);
+  });
+
+  test("in-progress appointment update can add service despite downstream booking", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      invoiceId,
+      adminId,
+      userId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+      addOnServiceId,
+    } = await createAdjustmentFixture(t, { appointmentStatus: "in_progress" });
+
+    await t.run(async (ctx: any) => {
+      await ctx.db.insert("appointments", {
+        userId,
+        vehicleIds: [secondVehicleId],
+        serviceIds: [baseServiceId],
+        scheduledDate: APPOINTMENT_TEST_DATE,
+        scheduledTime: "12:15",
+        duration: 60,
+        location: {
+          street: "456 Main St",
+          city: "Little Rock",
+          state: "AR",
+          zip: "72205",
+        },
+        status: "confirmed",
+        totalPrice: 100,
+        createdBy: adminId,
+      });
+    });
+
+    await asAdmin.mutation(api.appointments.update, {
+      appointmentId,
+      userId,
+      vehicleIds: [vehicleId],
+      serviceIds: [baseServiceId, addOnServiceId],
+      scheduledDate: APPOINTMENT_TEST_DATE,
+      scheduledTime: "10:00",
+      street: "123 Main St",
+      city: "Little Rock",
+      state: "AR",
+      zip: "72205",
+    });
+
+    const updated = await t.run(async (ctx: any) => {
+      const appointment = await ctx.db.get(appointmentId);
+      const invoice = await ctx.db.get(invoiceId);
+      return { appointment, invoice };
+    });
+
+    expect(updated.appointment?.serviceIds).toEqual([baseServiceId, addOnServiceId]);
+    expect(updated.appointment?.duration).toBe(165);
+    expect(updated.appointment?.totalPrice).toBe(160);
+    expect(updated.invoice?.total).toBe(160);
+  });
+
+  test("in-progress work adjustment can add service despite downstream booking", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      adminId,
+      userId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+      addOnServiceId,
+    } = await createAdjustmentFixture(t, { appointmentStatus: "in_progress" });
+
+    await t.run(async (ctx: any) => {
+      await ctx.db.insert("appointments", {
+        userId,
+        vehicleIds: [secondVehicleId],
+        serviceIds: [baseServiceId],
+        scheduledDate: APPOINTMENT_TEST_DATE,
+        scheduledTime: "12:15",
+        duration: 60,
+        location: {
+          street: "456 Main St",
+          city: "Little Rock",
+          state: "AR",
+          zip: "72205",
+        },
+        status: "confirmed",
+        totalPrice: 100,
+        createdBy: adminId,
+      });
+    });
+
+    const result = await asAdmin.mutation(api.appointments.applyWorkAdjustment, {
+      appointmentId,
+      vehicleIds: [vehicleId],
+      serviceIds: [baseServiceId, addOnServiceId],
+      petFeeVehicleIds: [],
+      reason: "Customer approved extra work on site",
+    });
+
+    const appointment = await t.run(
+      async (ctx: any) => (await ctx.db.get(appointmentId)) as any,
+    );
+
+    expect(result.invoiceAction).toBe("updated_open_invoice");
+    expect(appointment?.serviceIds).toEqual([baseServiceId, addOnServiceId]);
+    expect(appointment?.duration).toBe(165);
+    expect(appointment?.totalPrice).toBe(160);
   });
 
   test("work adjustment creates a supplemental invoice for paid invoice increases", async () => {

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -1014,8 +1014,13 @@ export const update = mutation({
     });
     const materialChanged =
       materialChangeFingerprint !== previousMaterialFingerprint;
+    const isInProgressWorkOnlyChange =
+      existingAppointment.status === "in_progress" && !scheduleChanged;
 
-    if (scheduleChanged || duration !== existingAppointment.duration) {
+    if (
+      (scheduleChanged || duration !== existingAppointment.duration) &&
+      !isInProgressWorkOnlyChange
+    ) {
       const slotAvailability = await ctx.runQuery(api.availability.checkAvailability, {
         date: normalizeDateKey(updates.scheduledDate),
         startTime: updates.scheduledTime,
@@ -1224,17 +1229,19 @@ export const applyWorkAdjustment = mutation({
     const priceDelta = Math.round((newPricing.totalPrice - appointment.totalPrice) * 100) / 100;
     const durationDelta = newPricing.duration - appointment.duration;
 
-    const availability = await ctx.runQuery(api.availability.checkAvailability, {
-      date: appointment.scheduledDate,
-      startTime: appointment.scheduledTime,
-      duration: newPricing.duration,
-      ignoreAppointmentId: args.appointmentId,
-    });
-    if (!availability.available) {
-      throw new ConvexError({
-        code: "TIME_SLOT_UNAVAILABLE",
-        message: availability.reason || "Adjusted work no longer fits this time slot.",
+    if (appointment.status !== "in_progress") {
+      const availability = await ctx.runQuery(api.availability.checkAvailability, {
+        date: appointment.scheduledDate,
+        startTime: appointment.scheduledTime,
+        duration: newPricing.duration,
+        ignoreAppointmentId: args.appointmentId,
       });
+      if (!availability.available) {
+        throw new ConvexError({
+          code: "TIME_SLOT_UNAVAILABLE",
+          message: availability.reason || "Adjusted work no longer fits this time slot.",
+        });
+      }
     }
 
     const invoice = await ctx.db


### PR DESCRIPTION
## Summary

Allows admins to add or remove services on appointments that are already in progress without failing the save because the expanded duration overlaps an existing booking.

## Implementation Notes

- Keeps normal availability validation for schedule changes and pre-start appointment edits.
- Skips availability revalidation for in-progress work-only changes where the date/start time stay the same.
- Applies the same behavior to the dedicated Adjust Work mutation.
- Adds regression coverage for both appointment update and Adjust Work when a downstream booking would otherwise trigger TIME_SLOT_UNAVAILABLE.

## Testing Notes

- bun run vitest run convex/appointments.test.ts
- bun run lint
- git diff --check

Closes #104