### PR TITLE
fix: allow active pending appointment service edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the River City Mobile Detailing project are documented in
 - **Service Descriptions at Checkout (Dashboard)**: Made services in the customer dashboard appointment booking summary clickable, revealing a Dialog containing complete service descriptions, matching the public booking flow behavior.
 
 ### Fixed
+- **Active Appointment Service Edits**: Allowed admins to add services to already-started pending appointments without rebooking the active time slot.
 - **In-Progress Work Adjustments**: Allowed admins to add or remove services on in-progress appointments without failing availability checks for the already-started time slot.
 - **Service Deletion Guidance**: Added a clear hide path for services with appointment history so admins can remove them from new bookings without breaking existing appointment records.
 - **HEIC Image Upload Fallbacks**: Fixed HEIC/HEIF photo uploads being rejected with a "client error" when browser MIME types fallback to `application/octet-stream`. Falls back to parsing filename extensions and maps them to `image/heic`/`image/heif` or relaxes backend verification to match.

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -8,6 +8,7 @@ import { seedBookingSetup } from "./testUtils/bookingSetup";
 import { r2 } from "./r2";
 
 const APPOINTMENT_TEST_DATE = "2024-12-02"; // Monday (dayOfWeek 1)
+const FUTURE_APPOINTMENT_TEST_DATE = "2999-12-02"; // Monday (dayOfWeek 1)
 
 async function expectConvexErrorCode(
   promise: Promise<unknown>,
@@ -730,6 +731,119 @@ describe("appointments", () => {
     expect(updated.appointment?.duration).toBe(165);
     expect(updated.appointment?.totalPrice).toBe(160);
     expect(updated.invoice?.total).toBe(160);
+  });
+
+  test("already-started pending appointment update can add service despite downstream booking", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      invoiceId,
+      adminId,
+      userId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+      addOnServiceId,
+    } = await createAdjustmentFixture(t, { appointmentStatus: "pending" });
+
+    await t.run(async (ctx: any) => {
+      await ctx.db.insert("appointments", {
+        userId,
+        vehicleIds: [secondVehicleId],
+        serviceIds: [baseServiceId],
+        scheduledDate: APPOINTMENT_TEST_DATE,
+        scheduledTime: "12:15",
+        duration: 60,
+        location: {
+          street: "456 Main St",
+          city: "Little Rock",
+          state: "AR",
+          zip: "72205",
+        },
+        status: "confirmed",
+        totalPrice: 100,
+        createdBy: adminId,
+      });
+    });
+
+    await asAdmin.mutation(api.appointments.update, {
+      appointmentId,
+      userId,
+      vehicleIds: [vehicleId],
+      serviceIds: [baseServiceId, addOnServiceId],
+      scheduledDate: APPOINTMENT_TEST_DATE,
+      scheduledTime: "10:00",
+      street: "123 Main St",
+      city: "Little Rock",
+      state: "AR",
+      zip: "72205",
+    });
+
+    const updated = await t.run(async (ctx: any) => {
+      const appointment = await ctx.db.get(appointmentId);
+      const invoice = await ctx.db.get(invoiceId);
+      return { appointment, invoice };
+    });
+
+    expect(updated.appointment?.status).toBe("pending");
+    expect(updated.appointment?.serviceIds).toEqual([baseServiceId, addOnServiceId]);
+    expect(updated.appointment?.duration).toBe(165);
+    expect(updated.appointment?.totalPrice).toBe(160);
+    expect(updated.invoice?.total).toBe(160);
+  });
+
+  test("future pending appointment update still blocks service additions that overlap", async () => {
+    const t = convexTest(schema, modules);
+    const {
+      asAdmin,
+      appointmentId,
+      adminId,
+      userId,
+      vehicleId,
+      secondVehicleId,
+      baseServiceId,
+      addOnServiceId,
+    } = await createAdjustmentFixture(t, { appointmentStatus: "pending" });
+
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(appointmentId, {
+        scheduledDate: FUTURE_APPOINTMENT_TEST_DATE,
+      });
+      await ctx.db.insert("appointments", {
+        userId,
+        vehicleIds: [secondVehicleId],
+        serviceIds: [baseServiceId],
+        scheduledDate: FUTURE_APPOINTMENT_TEST_DATE,
+        scheduledTime: "12:15",
+        duration: 60,
+        location: {
+          street: "456 Main St",
+          city: "Little Rock",
+          state: "AR",
+          zip: "72205",
+        },
+        status: "confirmed",
+        totalPrice: 100,
+        createdBy: adminId,
+      });
+    });
+
+    await expectConvexErrorCode(
+      asAdmin.mutation(api.appointments.update, {
+        appointmentId,
+        userId,
+        vehicleIds: [vehicleId],
+        serviceIds: [baseServiceId, addOnServiceId],
+        scheduledDate: FUTURE_APPOINTMENT_TEST_DATE,
+        scheduledTime: "10:00",
+        street: "123 Main St",
+        city: "Little Rock",
+        state: "AR",
+        zip: "72205",
+      }),
+      "TIME_SLOT_UNAVAILABLE",
+    );
   });
 
   test("in-progress work adjustment can add service despite downstream booking", async () => {

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -272,6 +272,37 @@ function getScheduleFingerprint(
   return `${scheduledDate}|${scheduledTime}`;
 }
 
+function getBusinessDateTimeParts(now = new Date()) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Chicago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const partMap = Object.fromEntries(
+    parts.map((part) => [part.type, part.value]),
+  );
+
+  return {
+    date: `${partMap.year}-${partMap.month}-${partMap.day}`,
+    time: `${partMap.hour}:${partMap.minute}`,
+  };
+}
+
+function hasAppointmentStarted(
+  scheduledDate: string,
+  scheduledTime: string,
+  now = new Date(),
+): boolean {
+  const dateKey = normalizeDateKey(scheduledDate);
+  const current = getBusinessDateTimeParts(now);
+
+  return dateKey < current.date || (dateKey === current.date && scheduledTime <= current.time);
+}
+
 async function scheduleReminder(
   ctx: any,
   appointmentId: Id<"appointments">,
@@ -987,11 +1018,13 @@ export const update = mutation({
       petFeeTimeMinutes: petFee.petFeeTimeMinutes,
     });
 
+    const normalizedScheduledDate = normalizeDateKey(updates.scheduledDate);
+    const existingScheduledDate = normalizeDateKey(existingAppointment.scheduledDate);
     const scheduleChanged =
-      existingAppointment.scheduledDate !== updates.scheduledDate ||
+      existingScheduledDate !== normalizedScheduledDate ||
       existingAppointment.scheduledTime !== updates.scheduledTime;
     const materialChangeFingerprint = JSON.stringify({
-      scheduledDate: updates.scheduledDate,
+      scheduledDate: normalizedScheduledDate,
       scheduledTime: updates.scheduledTime,
       street: updates.street,
       city: updates.city,
@@ -1002,7 +1035,7 @@ export const update = mutation({
       vehicleIds: [...updates.vehicleIds].sort(),
     });
     const previousMaterialFingerprint = JSON.stringify({
-      scheduledDate: existingAppointment.scheduledDate,
+      scheduledDate: existingScheduledDate,
       scheduledTime: existingAppointment.scheduledTime,
       street: existingAppointment.location.street,
       city: existingAppointment.location.city,
@@ -1014,15 +1047,18 @@ export const update = mutation({
     });
     const materialChanged =
       materialChangeFingerprint !== previousMaterialFingerprint;
-    const isInProgressWorkOnlyChange =
-      existingAppointment.status === "in_progress" && !scheduleChanged;
+    const isActiveWorkOnlyChange =
+      !scheduleChanged &&
+      ["pending", "confirmed", "in_progress"].includes(existingAppointment.status) &&
+      (existingAppointment.status === "in_progress" ||
+        hasAppointmentStarted(existingScheduledDate, existingAppointment.scheduledTime));
 
     if (
       (scheduleChanged || duration !== existingAppointment.duration) &&
-      !isInProgressWorkOnlyChange
+      !isActiveWorkOnlyChange
     ) {
       const slotAvailability = await ctx.runQuery(api.availability.checkAvailability, {
-        date: normalizeDateKey(updates.scheduledDate),
+        date: normalizedScheduledDate,
         startTime: updates.scheduledTime,
         duration,
         ignoreAppointmentId: appointmentId,
@@ -1046,7 +1082,7 @@ export const update = mutation({
       vehicleIds: updates.vehicleIds,
       serviceIds: updates.serviceIds,
       vehicleServices,
-      scheduledDate: normalizeDateKey(updates.scheduledDate),
+      scheduledDate: normalizedScheduledDate,
       scheduledTime: updates.scheduledTime,
       duration,
       location: {
@@ -1097,7 +1133,7 @@ export const update = mutation({
         await scheduleReminder(
           ctx,
           appointmentId,
-          updates.scheduledDate,
+          normalizedScheduledDate,
           updates.scheduledTime,
         );
       }
@@ -1229,7 +1265,12 @@ export const applyWorkAdjustment = mutation({
     const priceDelta = Math.round((newPricing.totalPrice - appointment.totalPrice) * 100) / 100;
     const durationDelta = newPricing.duration - appointment.duration;
 
-    if (appointment.status !== "in_progress") {
+    const isActiveWorkAdjustment =
+      ["pending", "confirmed", "in_progress"].includes(appointment.status) &&
+      (appointment.status === "in_progress" ||
+        hasAppointmentStarted(appointment.scheduledDate, appointment.scheduledTime));
+
+    if (!isActiveWorkAdjustment) {
       const availability = await ctx.runQuery(api.availability.checkAvailability, {
         date: appointment.scheduledDate,
         startTime: appointment.scheduledTime,


### PR DESCRIPTION
## Summary

Fixes the remaining TIME_SLOT_UNAVAILABLE case when an admin adds services to a job that has already started but is still marked pending.

## Implementation Notes

- Normalizes submitted appointment dates before comparing schedule changes.
- Treats pending, confirmed, and in-progress appointments whose original start time has passed as active work edits when date/time are unchanged.
- Keeps availability validation for future appointments and real date/time changes.
- Applies the same active-work logic to the Adjust Work mutation.
- Adds regression coverage for already-started pending edits and future pending overlap blocking.

## Testing Notes

- bun run vitest run convex/appointments.test.ts
- bun run lint
- git diff --check

Closes #106