### PR TITLE
fix: show appointment service prices by vehicle type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the River City Mobile Detailing project are documented in
 
 ---
 
+## [v1.0.5] - 2026-07-18
+### Added
+- **Booking Checkout Promo Codes**: Added a promo code input to the booking checkout order summary with live red/green validation feedback. Codes resolve against Stripe promotion codes first, then coupon IDs, enforcing usage rules (active status, expiration, redemption caps, minimum order value). Full-payment checkouts apply the coupon via Stripe `discounts`; deposit bookings apply the discount to the remaining balance invoice.
+- **Discounts on Active Appointments**: Admins can now apply, replace, or remove coupons on pending, confirmed, and in-progress appointments whenever the invoice still has a collectible balance — including invoices marked paid with a remaining balance (e.g. after manual mark-paid). Applying re-opens the invoice and reissues the Stripe invoice for the reduced balance.
+
+### Fixed
+- **Appointment Service Prices by Vehicle Type**: Appointment detail pricing now reflects per-vehicle-type service pricing.
+- **Mobile Appointment Actions**: The appointment detail page CTAs now stack below the back button on mobile instead of crowding the same row.
+
+---
+
 ## [v1.0.4] - 2026-06-18
 ### Added
 - **Editable Customer Vehicles (Admin)**: Expanded the admin Customer Detail page to allow inline editing of customer vehicles (Year, Make, Model, Color, License Plate, Notes). This triggers auto-classification on save to update sizes and types without needing deletion.

--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -54,6 +54,11 @@ import { toast } from "sonner";
 import { useEffect, useState } from "react";
 import { formatDateStringLong } from "@/lib/time";
 import { normalizeStripeCouponCode } from "@/convex/lib/coupons";
+import {
+  getEffectiveServicePricingForVehicle,
+  type ServiceVehiclePriceShape,
+  type VehicleSize,
+} from "@/convex/lib/pricing";
 
 type Props = {
   appointmentId: Id<"appointments">;
@@ -65,6 +70,7 @@ type AppointmentVehicle = Doc<"vehicles"> & {
 
 type AppointmentService = Doc<"services"> & {
   effectivePrice?: number;
+  vehiclePrices?: ServiceVehiclePriceShape[];
 };
 
 type AppointmentBeforePhoto = NonNullable<Doc<"appointments">["beforePhotos"]>[number] & {
@@ -103,16 +109,6 @@ function formatMinutes(minutes: number) {
   if (hours === 0) return `${sign}${remainder} min`;
   if (remainder === 0) return `${sign}${hours} hr`;
   return `${sign}${hours} hr ${remainder} min`;
-}
-
-function getEffectivePrice(
-  service: { basePrice?: number; basePriceSmall?: number; basePriceMedium?: number; basePriceLarge?: number },
-  size: string,
-): number {
-  const fallback = service.basePrice ?? 0;
-  if (size === "small") return service.basePriceSmall ?? service.basePriceMedium ?? fallback;
-  if (size === "large") return service.basePriceLarge ?? service.basePriceMedium ?? fallback;
-  return service.basePriceMedium ?? fallback;
 }
 
 export default function AppointmentDetailClient({ appointmentId }: Props) {
@@ -1082,8 +1078,17 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
                   .filter((s) => s.isActive)
                   .map((s) => {
                     const isSelected = editServiceIds.includes(s._id);
-                    const editVehicleSize = vehicles[0] ? (editVehicleSizes[vehicles[0]._id] || "medium") : "medium";
-                    const price = getEffectivePrice(s, editVehicleSize);
+                    const editVehicle = vehicles[0];
+                    const editVehicleSize = (editVehicle
+                      ? editVehicleSizes[editVehicle._id] || "medium"
+                      : "medium") as VehicleSize;
+                    const editVehicleTypeId = editVehicle
+                      ? editVehicleTypeIds[editVehicle._id] || null
+                      : null;
+                    const price = getEffectiveServicePricingForVehicle(s, {
+                      vehicleSize: editVehicleSize,
+                      vehicleTypeId: editVehicleTypeId,
+                    }).price;
                     return (
                       <div
                         key={s._id}

--- a/components/admin/appointment-detail-client.tsx
+++ b/components/admin/appointment-detail-client.tsx
@@ -598,20 +598,24 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
     (invoice.paymentOption ?? "deposit") === "deposit" &&
     (invoice.remainingBalance ?? 0) > 0 &&
     invoice.status !== "paid";
+  const canApplyDiscount =
+    !!invoice &&
+    canEdit &&
+    (invoice.status !== "paid" || (invoice.remainingBalance ?? 0) > 0);
   const canReissueBilling = canEditBilling && !!invoice?.stripeInvoiceId;
   const adjustmentBlockedByCredit =
     adjustmentPreview?.invoicePaid === true && adjustmentPreview.priceDelta < 0;
 
   return (
     <div className="space-y-6 animate-fade-in">
-      <div className="flex items-center justify-between">
-        <Button variant="ghost" asChild>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button variant="ghost" asChild className="w-fit">
           <Link href="/admin/appointments">
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Appointments
           </Link>
         </Button>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {canEdit && !editing && (
             <Button size="sm" variant="outline" onClick={startEditing}>
               <Pencil className="mr-2 h-4 w-4" />
@@ -693,7 +697,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
       )}
       {canEdit &&
         invoice &&
-        invoice.status !== "paid" && (
+        (invoice.status !== "paid" || (invoice.remainingBalance ?? 0) > 0) && (
           <div className="rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-100">
             You can edit appointment details, adjust work, and apply discounts
             until completion. Complete only after the invoice reflects the final
@@ -1330,7 +1334,7 @@ export default function AppointmentDetailClient({ appointmentId }: Props) {
               </div>
             )}
 
-            {invoice && invoice.status !== "paid" && (
+            {invoice && canApplyDiscount && (
               <div className="space-y-3 rounded-md border p-3 bg-muted/20 mt-4">
                 <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
                   <Tag className="h-3 w-3" />

--- a/components/booking/booking-flow.tsx
+++ b/components/booking/booking-flow.tsx
@@ -54,6 +54,7 @@ import {
   ChevronDown,
   ChevronUp,
   Loader2,
+  Tag,
   X,
 } from "lucide-react";
 import AddressInput from "@/components/ui/address-input";
@@ -237,6 +238,17 @@ export default function BookingFlow() {
     hasPet: false,
   });
   const [isReviewSubmitting, setIsReviewSubmitting] = useState(false);
+  const [promoCodeInput, setPromoCodeInput] = useState("");
+  const [promoStatus, setPromoStatus] = useState<
+    "idle" | "checking" | "valid" | "invalid"
+  >("idle");
+  const [promoMessage, setPromoMessage] = useState("");
+  const [appliedCoupon, setAppliedCoupon] = useState<{
+    code: string;
+    discountType: "percent" | "amount";
+    discountValue: number;
+    discountAmount: number;
+  } | null>(null);
 
   const step1Form = useForm<Step1Data>({
     resolver: zodResolver(step1Schema),
@@ -266,6 +278,7 @@ export default function BookingFlow() {
   const upsertBookingDraft = useAction(api.bookingDrafts.createOrUpdate);
   const calculateTravelFee = useAction(api.travelFees.calculate);
   const createBookingCheckout = useAction(api.payments.createBookingCheckout);
+  const validateBookingPromoCode = useAction(api.payments.validateBookingPromoCode);
   const saveOutOfAreaLead = useMutation(api.bookingDrafts.saveOutOfAreaLead);
   const saveOutOfAreaRequest = useMutation(api.bookingDrafts.saveOutOfAreaRequest);
   const convex = useConvex();
@@ -282,6 +295,98 @@ export default function BookingFlow() {
       vehicleTypeId: vehicle.vehicleTypeId ?? null,
     }));
   }, [step3Data?.vehicles]);
+
+  const checkoutSummary = useMemo(() => {
+    const petFeeForSize = (size: "small" | "medium" | "large") => {
+      if (petFeeSettings?.isActive === false) return 0;
+      if (size === "small") {
+        return petFeeSettings?.basePriceSmall ?? petFeeSettings?.basePriceMedium ?? 50;
+      }
+      if (size === "large") {
+        return petFeeSettings?.basePriceLarge ?? petFeeSettings?.basePriceMedium ?? 50;
+      }
+      return petFeeSettings?.basePriceMedium ?? 50;
+    };
+
+    const vehicles = step3Data?.vehicles ?? [];
+    let serviceTotal = 0;
+    const serviceBreakdownItems: Array<{
+      vehicleLabel: string;
+      serviceName: string;
+      serviceDescription: string;
+      price: number;
+      isSubscription: boolean;
+    }> = [];
+
+    vehicles.forEach((vehicle, idx) => {
+      const vServiceIds = step4Data?.vehicleServices?.[idx.toString()] || step4Data?.serviceIds || [];
+      const vehicleLabel = [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ") || `Vehicle ${idx + 1}`;
+      const vehicleContext = {
+        vehicleSize: (vehicle.size ?? "medium") as VehicleSize,
+        vehicleTypeId: vehicle.vehicleTypeId ?? null,
+      };
+
+      const vehicleServices = services?.filter((s) => vServiceIds.includes(s._id)) ?? [];
+      vehicleServices.forEach((service) => {
+        const price = getEffectiveServicePricingForVehicle(service, vehicleContext).price;
+        serviceTotal += price;
+        serviceBreakdownItems.push({
+          vehicleLabel,
+          serviceName: service.name,
+          serviceDescription: service.description || "No description available.",
+          price,
+          isSubscription: service.serviceType === "subscription",
+        });
+      });
+    });
+
+    const petFeeTotal = vehicles.reduce((sum, vehicle) => {
+      if (!vehicle.hasPet) return sum;
+      return sum + petFeeForSize(vehicle.size ?? "medium");
+    }, 0);
+    const travelFeeTotal = travelQuote?.fee ?? 0;
+    const orderTotal = serviceTotal + petFeeTotal + travelFeeTotal;
+
+    return { serviceTotal, serviceBreakdownItems, petFeeTotal, travelFeeTotal, orderTotal };
+  }, [step3Data?.vehicles, step4Data, services, petFeeSettings, travelQuote?.fee]);
+
+  // Live-validate promo codes as the customer types (debounced). The result
+  // drives the red/green input feedback and is re-checked whenever the order
+  // total changes so usage rules like minimum spend stay enforced.
+  useEffect(() => {
+    const code = promoCodeInput.trim();
+    if (!code) {
+      setPromoStatus("idle");
+      setPromoMessage("");
+      setAppliedCoupon(null);
+      return;
+    }
+    setPromoStatus("checking");
+    const handle = setTimeout(() => {
+      void (async () => {
+        try {
+          const result = await validateBookingPromoCode({
+            code,
+            orderTotal: checkoutSummary.orderTotal,
+          });
+          setAppliedCoupon(result);
+          setPromoStatus("valid");
+          setPromoMessage(
+            result.discountType === "percent"
+              ? `${result.code} applied — ${result.discountValue}% off`
+              : `${result.code} applied — $${result.discountValue.toFixed(2)} off`,
+          );
+        } catch (error) {
+          setAppliedCoupon(null);
+          setPromoStatus("invalid");
+          setPromoMessage(
+            error instanceof Error ? error.message : "This promo code is not valid.",
+          );
+        }
+      })();
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [promoCodeInput, checkoutSummary.orderTotal, validateBookingPromoCode]);
 
   const watchedStreet = step1Form.watch("street");
   const watchedCity = step1Form.watch("city");
@@ -1054,6 +1159,7 @@ export default function BookingFlow() {
       const { url } = await createBookingCheckout({
         draftId,
         origin: window.location.origin,
+        couponCode: appliedCoupon?.code ?? "",
       });
 
       if (url) {
@@ -2017,58 +2123,22 @@ export default function BookingFlow() {
           const vehicleCount = vehiclePricingContexts.length;
           const depositPerVehicle = depositSettings?.amountPerVehicle ?? 50;
           const depositTotal = depositPerVehicle * vehicleCount;
-          const petFeeForSize = (size: "small" | "medium" | "large") => {
-            if (petFeeSettings?.isActive === false) return 0;
-            if (size === "small") {
-              return petFeeSettings?.basePriceSmall ?? petFeeSettings?.basePriceMedium ?? 50;
-            }
-            if (size === "large") {
-              return petFeeSettings?.basePriceLarge ?? petFeeSettings?.basePriceMedium ?? 50;
-            }
-            return petFeeSettings?.basePriceMedium ?? 50;
-          };
+          const {
+            serviceTotal,
+            serviceBreakdownItems,
+            petFeeTotal,
+            travelFeeTotal,
+            orderTotal,
+          } = checkoutSummary;
+          const discountAmount = appliedCoupon
+            ? appliedCoupon.discountType === "percent"
+              ? Math.round(orderTotal * (appliedCoupon.discountValue / 100) * 100) / 100
+              : Math.min(appliedCoupon.discountValue, orderTotal)
+            : 0;
+          const discountedTotal = Math.max(0, Math.round((orderTotal - discountAmount) * 100) / 100);
 
-          const vehicles = step3Data?.vehicles ?? [];
-          let serviceTotal = 0;
-          const serviceBreakdownItems: Array<{
-            vehicleLabel: string;
-            serviceName: string;
-            serviceDescription: string;
-            price: number;
-            isSubscription: boolean;
-          }> = [];
-
-          vehicles.forEach((vehicle, idx) => {
-            const vServiceIds = step4Data?.vehicleServices?.[idx.toString()] || step4Data?.serviceIds || [];
-            const vehicleLabel = [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ") || `Vehicle ${idx + 1}`;
-            const vehicleContext = {
-              vehicleSize: (vehicle.size ?? "medium") as VehicleSize,
-              vehicleTypeId: vehicle.vehicleTypeId ?? null,
-            };
-
-            const vehicleServices = services?.filter((s) => vServiceIds.includes(s._id)) ?? [];
-            vehicleServices.forEach((service) => {
-              const price = getEffectiveServicePricingForVehicle(service, vehicleContext).price;
-              serviceTotal += price;
-              serviceBreakdownItems.push({
-                vehicleLabel,
-                serviceName: service.name,
-                serviceDescription: service.description || "No description available.",
-                price,
-                isSubscription: service.serviceType === "subscription",
-              });
-            });
-          });
-
-          const petFeeTotal = (step3Data?.vehicles ?? []).reduce((sum, vehicle) => {
-            if (!vehicle.hasPet) return sum;
-            return sum + petFeeForSize(vehicle.size ?? "medium");
-          }, 0);
-          const travelFeeTotal = travelQuote?.fee ?? 0;
-          const orderTotal = serviceTotal + petFeeTotal + travelFeeTotal;
-
-          const dueNow = paymentOption === "full" ? orderTotal : Math.min(depositTotal, orderTotal);
-          const remainingBalance = Math.max(0, orderTotal - dueNow);
+          const dueNow = paymentOption === "full" ? discountedTotal : Math.min(depositTotal, discountedTotal);
+          const remainingBalance = Math.max(0, discountedTotal - dueNow);
 
           return (
             <div className="space-y-6">
@@ -2123,9 +2193,18 @@ export default function BookingFlow() {
                     <span className="text-foreground">${travelFeeTotal.toFixed(2)}</span>
                   </div>
                 )}
+                {appliedCoupon && discountAmount > 0 && (
+                  <div className="flex justify-between text-sm font-medium mt-1">
+                    <span className="text-green-600 flex items-center gap-1">
+                      <Tag className="h-3 w-3" />
+                      Discount ({appliedCoupon.code})
+                    </span>
+                    <span className="text-green-600">-${discountAmount.toFixed(2)}</span>
+                  </div>
+                )}
                 <div className="flex justify-between border-t border-border/50 pt-2 text-base font-bold mt-2">
                   <span className="text-foreground">Total</span>
-                  <span className="text-foreground">${orderTotal.toFixed(2)}</span>
+                  <span className="text-foreground">${discountedTotal.toFixed(2)}</span>
                 </div>
                 {paymentOption !== "full" && (
                   <div className="mt-3 space-y-1 border-t border-border/30 pt-3">
@@ -2139,6 +2218,51 @@ export default function BookingFlow() {
                     </div>
                   </div>
                 )}
+
+                {/* Promo Code */}
+                <div className="mt-3 border-t border-border/30 pt-3">
+                  <div className="relative">
+                    <Input
+                      placeholder="Promo code"
+                      value={promoCodeInput}
+                      onChange={(e) => setPromoCodeInput(e.target.value)}
+                      className={`h-9 pr-8 text-sm uppercase ${
+                        promoStatus === "valid"
+                          ? "border-green-500 focus-visible:ring-green-500"
+                          : promoStatus === "invalid"
+                            ? "border-red-500 focus-visible:ring-red-500"
+                            : ""
+                      }`}
+                      aria-invalid={promoStatus === "invalid"}
+                    />
+                    <span className="absolute right-2.5 top-1/2 -translate-y-1/2">
+                      {promoStatus === "checking" && (
+                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                      )}
+                      {promoStatus === "valid" && (
+                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                      )}
+                      {promoStatus === "invalid" && (
+                        <X className="h-4 w-4 text-red-500" />
+                      )}
+                    </span>
+                  </div>
+                  {promoStatus === "valid" && promoMessage && (
+                    <p className="mt-1.5 text-xs font-medium text-green-600">
+                      {promoMessage}
+                    </p>
+                  )}
+                  {promoStatus === "invalid" && promoMessage && (
+                    <p className="mt-1.5 text-xs font-medium text-red-600">
+                      {promoMessage}
+                    </p>
+                  )}
+                  {promoStatus === "valid" && paymentOption !== "full" && (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      The discount applies to your remaining balance, not the deposit.
+                    </p>
+                  )}
+                </div>
               </div>
 
               {/* Payment Option Selector */}
@@ -2163,7 +2287,7 @@ export default function BookingFlow() {
                     <div>
                       <span className="font-semibold text-sm text-foreground">Pay Deposit Now</span>
                       <span className="text-xs text-muted-foreground block mt-0.5">
-                        ${Math.min(depositTotal, orderTotal).toFixed(2)} deposit now, remaining balance invoiced after service
+                        ${Math.min(depositTotal, discountedTotal).toFixed(2)} deposit now, remaining balance invoiced after service
                       </span>
                     </div>
                   </label>
@@ -2185,7 +2309,7 @@ export default function BookingFlow() {
                     <div>
                       <span className="font-semibold text-sm text-foreground">Pay Full Price Now</span>
                       <span className="text-xs text-muted-foreground block mt-0.5">
-                        ${orderTotal.toFixed(2)} — pay entire amount upfront
+                        ${discountedTotal.toFixed(2)} — pay entire amount upfront
                       </span>
                     </div>
                   </label>
@@ -2207,7 +2331,7 @@ export default function BookingFlow() {
                     <div>
                       <span className="font-semibold text-sm text-foreground">Pay Remaining in Person</span>
                       <span className="text-xs text-muted-foreground block mt-0.5">
-                        ${Math.min(depositTotal, orderTotal).toFixed(2)} deposit now, pay balance in cash/card at service
+                        ${Math.min(depositTotal, discountedTotal).toFixed(2)} deposit now, pay balance in cash/card at service
                       </span>
                     </div>
                   </label>

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -235,6 +235,106 @@ describe("appointments", () => {
     }
   });
 
+  test("appointment details use vehicle type matrix pricing over legacy size pricing", async () => {
+    const t = convexTest(schema, modules);
+    const { appointmentId, adminId } = await t.run(async (ctx) => {
+      const now = Date.now();
+      const adminId = await ctx.db.insert("users", {
+        name: "Matrix Admin",
+        email: "matrix-admin@example.com",
+        role: "admin",
+      });
+      const userId = await ctx.db.insert("users", {
+        name: "Matrix Customer",
+        email: "matrix-customer@example.com",
+        role: "client",
+      });
+      const carTypeId = await ctx.db.insert("vehicleTypes", {
+        name: "Car",
+        slug: "car",
+        legacySize: "small",
+        isActive: true,
+        displayOrder: 1,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const suvTypeId = await ctx.db.insert("vehicleTypes", {
+        name: "SUV",
+        slug: "suv",
+        legacySize: "medium",
+        isActive: true,
+        displayOrder: 2,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const vehicleId = await ctx.db.insert("vehicles", {
+        userId,
+        year: 2014,
+        make: "Buick",
+        model: "LaCrosse",
+        vehicleTypeId: carTypeId,
+        size: "medium",
+      });
+      const serviceId = await ctx.db.insert("services", {
+        name: "Level 3 - Full Detail",
+        description: "Full detail",
+        basePrice: 325,
+        basePriceSmall: 300,
+        basePriceMedium: 325,
+        duration: 170,
+        serviceType: "standard",
+        isActive: true,
+      });
+      await ctx.db.insert("serviceVehiclePrices", {
+        serviceId,
+        vehicleTypeId: carTypeId,
+        price: 300,
+        duration: 170,
+        isAvailable: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await ctx.db.insert("serviceVehiclePrices", {
+        serviceId,
+        vehicleTypeId: suvTypeId,
+        price: 325,
+        duration: 210,
+        isAvailable: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const appointmentId = await ctx.db.insert("appointments", {
+        userId,
+        vehicleIds: [vehicleId],
+        serviceIds: [serviceId],
+        scheduledDate: APPOINTMENT_TEST_DATE,
+        scheduledTime: "10:00",
+        duration: 170,
+        location: {
+          street: "123 Main St",
+          city: "Little Rock",
+          state: "AR",
+          zip: "72205",
+        },
+        status: "pending",
+        totalPrice: 300,
+        createdBy: adminId,
+      });
+      return { appointmentId, adminId };
+    });
+
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "matrix-admin@example.com",
+    });
+    const appointment = await asAdmin.query(api.appointments.getByIdWithDetails, {
+      appointmentId,
+    });
+
+    expect(appointment?.vehicles[0]?.vehicleType?.name).toBe("Car");
+    expect(appointment?.services[0]?.effectivePrice).toBe(300);
+  });
+
   test("create appointment", async () => {
     const t = convexTest(schema, modules);
     await seedBookingSetup(t);

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -673,11 +673,28 @@ export const getByIdWithDetails = query({
           : null,
       })));
 
-    const vehicleSize: VehicleSize = (vehicles[0]?.size as VehicleSize) || "medium";
-    const servicesWithPricing = services.map((s) => ({
-      ...s,
-      effectivePrice: getEffectiveServicePrice(s, vehicleSize),
-    }));
+    const primaryVehicle = vehicles[0] as Doc<"vehicles"> | undefined;
+    const servicesWithPricing = await Promise.all(
+      services.map(async (s) => {
+        if (!primaryVehicle) {
+          return {
+            ...s,
+            effectivePrice: getEffectiveServicePrice(s, "medium"),
+          };
+        }
+
+        const pricing = await getMatrixPriceForServiceAndVehicle(
+          ctx,
+          s,
+          primaryVehicle,
+        );
+
+        return {
+          ...s,
+          effectivePrice: pricing.unitPrice,
+        };
+      }),
+    );
 
     const invoice = await ctx.db
       .query("invoices")

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -965,6 +965,25 @@ export const markCheckoutOpenInternal = internalMutation({
   },
 });
 
+export const setCouponInternal = internalMutation({
+  args: {
+    draftId: v.id("bookingDrafts"),
+    couponCode: v.optional(v.string()),
+    couponDiscountType: v.optional(
+      v.union(v.literal("percent"), v.literal("amount")),
+    ),
+    couponDiscountValue: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.draftId, {
+      couponCode: args.couponCode,
+      couponDiscountType: args.couponDiscountType,
+      couponDiscountValue: args.couponDiscountValue,
+      lastActivityAt: Date.now(),
+    });
+  },
+});
+
 export const markCancelledInternal = internalMutation({
   args: {
     draftId: v.id("bookingDrafts"),
@@ -1036,6 +1055,33 @@ export const markAbandonedEmailSentInternal = internalMutation({
   },
 });
 
+function getDraftCouponDiscount(draft: Doc<"bookingDrafts">): {
+  couponCode?: string;
+  discountAmount: number;
+  discountedTotal: number;
+} {
+  const hasCouponSnapshot =
+    !!draft.couponCode &&
+    !!draft.couponDiscountType &&
+    draft.couponDiscountValue != null &&
+    draft.couponDiscountValue > 0;
+  const discountAmount = hasCouponSnapshot
+    ? draft.couponDiscountType === "percent"
+      ? Math.round(
+          draft.totalPrice * ((draft.couponDiscountValue ?? 0) / 100) * 100,
+        ) / 100
+      : Math.min(draft.couponDiscountValue ?? 0, draft.totalPrice)
+    : 0;
+  return {
+    couponCode: discountAmount > 0 ? draft.couponCode : undefined,
+    discountAmount,
+    discountedTotal: Math.max(
+      0,
+      Math.round((draft.totalPrice - discountAmount) * 100) / 100,
+    ),
+  };
+}
+
 export const convertSuccessfulCheckout = internalMutation({
   args: {
     draftId: v.id("bookingDrafts"),
@@ -1069,7 +1115,7 @@ export const convertSuccessfulCheckout = internalMutation({
         userId: draft.convertedUserId,
         paymentOption: draft.paymentOption,
         isFullPayment: draft.paymentOption === "full",
-        total: draft.totalPrice,
+        total: getDraftCouponDiscount(draft).discountedTotal,
       };
     }
 
@@ -1273,6 +1319,10 @@ export const convertSuccessfulCheckout = internalMutation({
     const today = new Date().toISOString().split("T")[0];
     const isFullPayment = draft.paymentOption === "full";
 
+    const couponDiscount = getDraftCouponDiscount(draft);
+    const discountAmount = couponDiscount.discountAmount;
+    const discountedTotal = couponDiscount.discountedTotal;
+
     const invoiceId: Id<"invoices"> = await ctx.db.insert("invoices", {
       appointmentId,
       userId: user._id,
@@ -1280,18 +1330,22 @@ export const convertSuccessfulCheckout = internalMutation({
       items: draft.priceSnapshot,
       subtotal: draft.totalPrice,
       tax: 0,
-      total: draft.totalPrice,
+      total: discountedTotal,
       status: isFullPayment ? "paid" : "draft",
       dueDate: dueDate.toISOString().split("T")[0],
       paidDate: isFullPayment ? today : undefined,
       notes: `Invoice for appointment on ${draft.scheduledDate}`,
-      depositAmount: draft.paymentOption === "full" ? draft.totalPrice : draft.depositAmount,
+      depositAmount: isFullPayment ? discountedTotal : draft.depositAmount,
       depositPaid: true,
       depositPaymentIntentId: args.paymentIntentId,
-      remainingBalance: isFullPayment ? 0 : draft.remainingBalance,
+      remainingBalance: isFullPayment
+        ? 0
+        : Math.max(0, Math.round((discountedTotal - draft.depositAmount) * 100) / 100),
       paymentOption: draft.paymentOption,
       remainingBalanceCollectionMethod:
         draft.paymentOption === "deposit" ? "send_invoice" : undefined,
+      couponCode: discountAmount > 0 ? draft.couponCode : undefined,
+      discountAmount: discountAmount > 0 ? discountAmount : undefined,
     });
 
     await ctx.db.patch(draft._id, {
@@ -1311,7 +1365,7 @@ export const convertSuccessfulCheckout = internalMutation({
       userId: user._id,
       paymentOption: draft.paymentOption,
       isFullPayment,
-      total: draft.totalPrice,
+      total: discountedTotal,
     };
   },
 });

--- a/convex/invoices.ts
+++ b/convex/invoices.ts
@@ -741,8 +741,8 @@ export const updateDiscount = internalMutation({
     if (!invoice) {
       throw new Error("Invoice not found");
     }
-    if (invoice.status === "paid") {
-      throw new Error("Paid invoices cannot be edited");
+    if (invoice.status === "paid" && (invoice.remainingBalance ?? 0) <= 0) {
+      throw new Error("Fully paid invoices cannot be edited");
     }
     await ctx.db.patch(args.invoiceId, {
       couponCode: args.couponCode,
@@ -753,6 +753,7 @@ export const updateDiscount = internalMutation({
       stripeInvoiceUrl: undefined,
       finalPaymentIntentId: undefined,
       status: invoice.depositPaid ? "draft" : invoice.status,
+      paidDate: invoice.status === "paid" ? undefined : invoice.paidDate,
     });
   },
 });
@@ -766,8 +767,8 @@ export const removeDiscount = internalMutation({
     if (!invoice) {
       throw new Error("Invoice not found");
     }
-    if (invoice.status === "paid") {
-      throw new Error("Paid invoices cannot be edited");
+    if (invoice.status === "paid" && (invoice.remainingBalance ?? 0) <= 0) {
+      throw new Error("Fully paid invoices cannot be edited");
     }
     const originalTotal = invoice.subtotal + invoice.tax;
     const newRemainingBalance = Math.max(0, originalTotal - (invoice.depositAmount || 0));
@@ -781,6 +782,7 @@ export const removeDiscount = internalMutation({
       stripeInvoiceUrl: undefined,
       finalPaymentIntentId: undefined,
       status: invoice.depositPaid ? "draft" : invoice.status,
+      paidDate: invoice.status === "paid" ? undefined : invoice.paidDate,
     });
   },
 });

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -2874,4 +2874,439 @@ describe("payments", () => {
     expect(invoice?.total).toBe(75);
     expect(invoice?.remainingBalance).toBe(25);
   });
+
+  test("applyCouponToInvoice allows a paid invoice that still has a remaining balance", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t, true);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin@test.com",
+        role: "admin",
+      });
+    });
+
+    const { invoiceId } = await createTestAppointmentWithInvoice(
+      t,
+      userId,
+      adminId,
+    );
+
+    // Simulate the reported state: invoice marked paid with a balance still owed
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(invoiceId, {
+        status: "paid",
+        depositPaid: true,
+        paidDate: "2024-12-01",
+      });
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, options?: RequestInit) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        if (urlString.includes("/coupons/")) {
+          return {
+            ok: true,
+            json: async () => ({ id: "SAVE20", valid: true }),
+          } as Response;
+        }
+        return stripeFetchMock(url, options);
+      }),
+    );
+
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin@test.com",
+    });
+
+    const applyResult = await asAdmin.action(api.payments.applyCouponToInvoice, {
+      invoiceId,
+      couponCode: "SAVE20",
+      discountType: "percent",
+      discountValue: 20,
+    });
+
+    expect(applyResult.success).toBe(true);
+    expect(applyResult.discountAmount).toBe(20);
+    expect(applyResult.newTotal).toBe(80);
+    expect(applyResult.newRemainingBalance).toBe(30);
+
+    const invoice = await t.run(async (ctx: any) => ctx.db.get(invoiceId));
+    expect(invoice?.couponCode).toBe("SAVE20");
+    expect(invoice?.discountAmount).toBe(20);
+    expect(invoice?.total).toBe(80);
+    expect(invoice?.remainingBalance).toBe(30);
+    // Re-opened so the reduced balance can be collected again
+    expect(invoice?.status).not.toBe("paid");
+    expect(invoice?.paidDate).toBeUndefined();
+  });
+
+  test("applyCouponToInvoice and removeDiscountFromInvoice reject fully settled invoices", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await createTestUser(t, true);
+    const adminId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("users", {
+        name: "Admin",
+        email: "admin@test.com",
+        role: "admin",
+      });
+    });
+
+    const { invoiceId } = await createTestAppointmentWithInvoice(
+      t,
+      userId,
+      adminId,
+    );
+
+    await t.run(async (ctx: any) => {
+      await ctx.db.patch(invoiceId, {
+        status: "paid",
+        depositPaid: true,
+        remainingBalance: 0,
+        paidDate: "2024-12-01",
+      });
+    });
+
+    const asAdmin = t.withIdentity({
+      subject: adminId,
+      email: "admin@test.com",
+    });
+
+    await expect(
+      asAdmin.action(api.payments.applyCouponToInvoice, {
+        invoiceId,
+        couponCode: "SAVE20",
+        discountType: "percent",
+        discountValue: 20,
+      }),
+    ).rejects.toThrow("Fully paid invoices cannot be modified");
+
+    await expect(
+      asAdmin.action(api.payments.removeDiscountFromInvoice, { invoiceId }),
+    ).rejects.toThrow("Fully paid invoices cannot be modified");
+  });
+
+  test("validateBookingPromoCode validates coupon ids and promotion codes", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, options?: RequestInit) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        if (urlString.includes("promotion_codes")) {
+          if (urlString.includes("SPRING25")) {
+            return {
+              ok: true,
+              json: async () => ({
+                data: [
+                  {
+                    id: "promo_spring25",
+                    active: true,
+                    code: "SPRING25",
+                    coupon: "SPRING25OFF",
+                  },
+                ],
+              }),
+            } as Response;
+          }
+          return { ok: true, json: async () => ({ data: [] }) } as Response;
+        }
+        if (urlString.includes("/coupons/SAVE20")) {
+          return {
+            ok: true,
+            json: async () => ({ id: "SAVE20", valid: true, percent_off: 20 }),
+          } as Response;
+        }
+        if (urlString.includes("/coupons/SPRING25OFF")) {
+          return {
+            ok: true,
+            json: async () => ({
+              id: "SPRING25OFF",
+              valid: true,
+              percent_off: 25,
+            }),
+          } as Response;
+        }
+        if (urlString.includes("/coupons/MAXED")) {
+          return {
+            ok: true,
+            json: async () => ({
+              id: "MAXED",
+              valid: true,
+              percent_off: 10,
+              max_redemptions: 5,
+              times_redeemed: 5,
+            }),
+          } as Response;
+        }
+        if (urlString.includes("/coupons/")) {
+          return {
+            ok: false,
+            status: 404,
+            text: async () => "Not found",
+          } as Response;
+        }
+        return stripeFetchMock(url, options);
+      }),
+    );
+
+    // Direct coupon id (case-insensitive input)
+    const couponResult = await t.action(api.payments.validateBookingPromoCode, {
+      code: "save20",
+      orderTotal: 150,
+    });
+    expect(couponResult).toEqual({
+      code: "SAVE20",
+      discountType: "percent",
+      discountValue: 20,
+      discountAmount: 30,
+    });
+
+    // Customer-facing promotion code resolves to its coupon
+    const promoResult = await t.action(api.payments.validateBookingPromoCode, {
+      code: "SPRING25",
+      orderTotal: 200,
+    });
+    expect(promoResult).toEqual({
+      code: "SPRING25OFF",
+      discountType: "percent",
+      discountValue: 25,
+      discountAmount: 50,
+    });
+
+    // Redemption limit is enforced
+    await expect(
+      t.action(api.payments.validateBookingPromoCode, {
+        code: "MAXED",
+        orderTotal: 100,
+      }),
+    ).rejects.toThrow("redemption limit");
+
+    // Unknown codes are rejected
+    await expect(
+      t.action(api.payments.validateBookingPromoCode, {
+        code: "NOPE",
+        orderTotal: 100,
+      }),
+    ).rejects.toThrow("not valid or has expired");
+  });
+
+  test("validateBookingPromoCode enforces promotion code minimum order amounts", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, options?: RequestInit) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        if (urlString.includes("promotion_codes")) {
+          return {
+            ok: true,
+            json: async () => ({
+              data: [
+                {
+                  id: "promo_big",
+                  active: true,
+                  code: "BIGORDER",
+                  coupon: "BIGCOUPON",
+                  restrictions: { minimum_amount: 20000 },
+                },
+              ],
+            }),
+          } as Response;
+        }
+        if (urlString.includes("/coupons/BIGCOUPON")) {
+          return {
+            ok: true,
+            json: async () => ({ id: "BIGCOUPON", valid: true, percent_off: 10 }),
+          } as Response;
+        }
+        return stripeFetchMock(url, options);
+      }),
+    );
+
+    await expect(
+      t.action(api.payments.validateBookingPromoCode, {
+        code: "BIGORDER",
+        orderTotal: 150,
+      }),
+    ).rejects.toThrow("minimum order of $200.00");
+
+    const result = await t.action(api.payments.validateBookingPromoCode, {
+      code: "BIGORDER",
+      orderTotal: 250,
+    });
+    expect(result.code).toBe("BIGCOUPON");
+    expect(result.discountAmount).toBe(25);
+  });
+
+  test("full-payment booking checkout applies the coupon and snapshots it on the draft", async () => {
+    const t = convexTest(schema, modules);
+    await seedBookingSetup(t, {
+      includeBookableService: false,
+      includeDepositSettings: true,
+    });
+
+    const serviceId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("services", {
+        name: "Full Pay Service",
+        description: "Service for full-payment coupon test",
+        basePrice: 100,
+        basePriceMedium: 100,
+        duration: 60,
+        serviceType: "standard",
+        isActive: true,
+      });
+    });
+
+    const booking = await t.action(api.bookingDrafts.createOrUpdate, {
+      name: "Full Pay Booker",
+      email: "full-pay@example.com",
+      phone: "555-7777",
+      address: {
+        street: "789 Full St",
+        city: "Springfield",
+        state: "IL",
+        zip: "62701",
+      },
+      vehicles: [{ year: 2022, make: "Tesla", model: "Model 3", size: "medium" }],
+      serviceIds: [serviceId],
+      scheduledDate: "2024-12-03",
+      scheduledTime: "10:00",
+      paymentOption: "full",
+    });
+
+    let checkoutRequestBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, options?: RequestInit) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        if (urlString.includes("promotion_codes")) {
+          return { ok: true, json: async () => ({ data: [] }) } as Response;
+        }
+        if (urlString.includes("/coupons/SAVE20")) {
+          return {
+            ok: true,
+            json: async () => ({ id: "SAVE20", valid: true, percent_off: 20 }),
+          } as Response;
+        }
+        if (urlString.includes("checkout/sessions")) {
+          if (options?.body instanceof URLSearchParams) {
+            checkoutRequestBody = options.body.toString();
+          } else if (typeof options?.body === "string") {
+            checkoutRequestBody = options.body;
+          }
+          return {
+            ok: true,
+            json: async () => ({
+              id: "cs_full_coupon_123",
+              url: "https://checkout.stripe.com/full-coupon",
+            }),
+          } as Response;
+        }
+        return stripeFetchMock(url, options);
+      }),
+    );
+
+    const checkout = await t.action(api.payments.createBookingCheckout, {
+      draftId: booking.draftId,
+      origin: "https://example.com",
+      couponCode: "SAVE20",
+    });
+
+    expect(checkout.sessionId).toBe("cs_full_coupon_123");
+    const bodyParams = new URLSearchParams(checkoutRequestBody);
+    expect(bodyParams.get("discounts[0][coupon]")).toBe("SAVE20");
+
+    const draft = await t.run(async (ctx: any) => ctx.db.get(booking.draftId));
+    expect(draft?.couponCode).toBe("SAVE20");
+    expect(draft?.couponDiscountType).toBe("percent");
+    expect(draft?.couponDiscountValue).toBe(20);
+
+    // Conversion prices the invoice from the snapshot so it matches the charge
+    const converted = await t.mutation(
+      internal.bookingDrafts.convertSuccessfulCheckout,
+      {
+        draftId: booking.draftId,
+        stripeCustomerId: "cus_full_coupon",
+        paymentIntentId: "pi_full_coupon",
+      },
+    );
+
+    expect(converted?.total).toBe(80);
+    const invoice = await t.run(async (ctx: any) =>
+      converted ? ctx.db.get(converted.invoiceId) : null,
+    );
+    expect(invoice?.status).toBe("paid");
+    expect(invoice?.subtotal).toBe(100);
+    expect(invoice?.couponCode).toBe("SAVE20");
+    expect(invoice?.discountAmount).toBe(20);
+    expect(invoice?.total).toBe(80);
+    expect(invoice?.depositAmount).toBe(80);
+    expect(invoice?.remainingBalance).toBe(0);
+  });
+
+  test("deposit checkout conversion applies the coupon snapshot to the remaining balance", async () => {
+    const t = convexTest(schema, modules);
+    await seedBookingSetup(t, {
+      includeBookableService: false,
+      includeDepositSettings: true,
+    });
+
+    const serviceId = await t.run(async (ctx: any) => {
+      return await ctx.db.insert("services", {
+        name: "Deposit Coupon Service",
+        description: "Service for deposit coupon test",
+        basePrice: 100,
+        basePriceMedium: 100,
+        duration: 60,
+        serviceType: "standard",
+        isActive: true,
+      });
+    });
+
+    const booking = await t.action(api.bookingDrafts.createOrUpdate, {
+      name: "Deposit Coupon Booker",
+      email: "deposit-coupon@example.com",
+      phone: "555-8888",
+      address: {
+        street: "321 Deposit St",
+        city: "Springfield",
+        state: "IL",
+        zip: "62701",
+      },
+      vehicles: [{ year: 2021, make: "Honda", model: "Civic", size: "medium" }],
+      serviceIds: [serviceId],
+      scheduledDate: "2024-12-04",
+      scheduledTime: "10:00",
+      paymentOption: "deposit",
+    });
+
+    await t.mutation(internal.bookingDrafts.setCouponInternal, {
+      draftId: booking.draftId,
+      couponCode: "SAVE20",
+      couponDiscountType: "percent",
+      couponDiscountValue: 20,
+    });
+
+    const converted = await t.mutation(
+      internal.bookingDrafts.convertSuccessfulCheckout,
+      {
+        draftId: booking.draftId,
+        stripeCustomerId: "cus_deposit_coupon",
+        paymentIntentId: "pi_deposit_coupon",
+      },
+    );
+
+    expect(converted?.total).toBe(80);
+    const invoice = await t.run(async (ctx: any) =>
+      converted ? ctx.db.get(converted.invoiceId) : null,
+    );
+    expect(invoice?.status).toBe("draft");
+    expect(invoice?.couponCode).toBe("SAVE20");
+    expect(invoice?.discountAmount).toBe(20);
+    expect(invoice?.total).toBe(80);
+    expect(invoice?.depositAmount).toBe(50);
+    expect(invoice?.remainingBalance).toBe(30);
+  });
 });

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -12,7 +12,7 @@ import { api, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { stripeClient } from "./stripeClient";
 import { BOOKING_BLOCK_MINUTES } from "./lib/booking";
-import { validateCouponInput } from "./lib/coupons";
+import { normalizeStripeCouponCode, validateCouponInput } from "./lib/coupons";
 import { assertRateLimit, normalizeRateLimitKey } from "./rateLimiter";
 
 const paymentsInternal: any = (internal as any).payments;
@@ -1807,8 +1807,8 @@ export const applyCouponToInvoice = action({
     if (!invoice) {
       throw new Error("Invoice not found");
     }
-    if (invoice.status === "paid") {
-      throw new Error("Paid invoices cannot be modified");
+    if (invoice.status === "paid" && (invoice.remainingBalance ?? 0) <= 0) {
+      throw new Error("Fully paid invoices cannot be modified");
     }
 
     // 1. Check if Coupon exists in Stripe. If not, create it from supplied terms.
@@ -1927,8 +1927,8 @@ export const removeDiscountFromInvoice = action({
     if (!invoice) {
       throw new Error("Invoice not found");
     }
-    if (invoice.status === "paid") {
-      throw new Error("Paid invoices cannot be modified");
+    if (invoice.status === "paid" && (invoice.remainingBalance ?? 0) <= 0) {
+      throw new Error("Fully paid invoices cannot be modified");
     }
 
     if (invoice.stripeInvoiceId) {
@@ -1956,6 +1956,171 @@ export const removeDiscountFromInvoice = action({
     }
 
     return { success: true };
+  },
+});
+
+type ResolvedStripeCoupon = {
+  couponId: string;
+  discountType: "percent" | "amount";
+  discountValue: number;
+};
+
+function assertStripeCouponRedeemable(stripeCoupon: any) {
+  if (!stripeCoupon || stripeCoupon.valid === false) {
+    throw new Error("This promo code is not valid or has expired.");
+  }
+  if (
+    typeof stripeCoupon.redeem_by === "number" &&
+    stripeCoupon.redeem_by * 1000 < Date.now()
+  ) {
+    throw new Error("This promo code is not valid or has expired.");
+  }
+  if (
+    typeof stripeCoupon.max_redemptions === "number" &&
+    (stripeCoupon.times_redeemed ?? 0) >= stripeCoupon.max_redemptions
+  ) {
+    throw new Error("This promo code has reached its redemption limit.");
+  }
+}
+
+// Promotion code usage rules: active flag, expiration, redemption cap, and
+// minimum order value. Note: first-time-transaction and per-customer
+// restrictions cannot be verified before checkout and are not enforced here.
+function assertPromotionCodeRedeemable(promo: any, orderTotal?: number) {
+  if (!promo || promo.active === false) {
+    throw new Error("This promo code is not valid or has expired.");
+  }
+  if (
+    typeof promo.expires_at === "number" &&
+    promo.expires_at * 1000 < Date.now()
+  ) {
+    throw new Error("This promo code is not valid or has expired.");
+  }
+  if (
+    typeof promo.max_redemptions === "number" &&
+    (promo.times_redeemed ?? 0) >= promo.max_redemptions
+  ) {
+    throw new Error("This promo code has reached its redemption limit.");
+  }
+  const minimumAmount = promo.restrictions?.minimum_amount;
+  if (
+    typeof minimumAmount === "number" &&
+    orderTotal !== undefined &&
+    Math.round(orderTotal * 100) < minimumAmount
+  ) {
+    throw new Error(
+      `This promo code requires a minimum order of $${(minimumAmount / 100).toFixed(2)}.`,
+    );
+  }
+}
+
+// Resolve a customer-entered code to a Stripe coupon: try customer-facing
+// promotion codes first, then fall back to the coupon ID format used by the
+// admin coupons dashboard.
+async function resolveStripeCouponForCode(
+  rawCode: string,
+  orderTotal?: number,
+): Promise<ResolvedStripeCoupon> {
+  const trimmed = rawCode.trim();
+  if (!trimmed) {
+    throw new Error("Please enter a promo code.");
+  }
+
+  try {
+    const promoResponse = await stripeApiCall(
+      `promotion_codes?active=true&limit=1&code=${encodeURIComponent(trimmed)}`,
+      { method: "GET" },
+    );
+    const promo = (promoResponse.data || [])[0];
+    if (promo?.coupon) {
+      assertPromotionCodeRedeemable(promo, orderTotal);
+      const couponId =
+        typeof promo.coupon === "string" ? promo.coupon : promo.coupon.id;
+      const stripeCoupon =
+        typeof promo.coupon === "string"
+          ? await stripeApiCall(`coupons/${encodeURIComponent(couponId)}`, {
+              method: "GET",
+            })
+          : promo.coupon;
+      assertStripeCouponRedeemable(stripeCoupon);
+      const discount = getDiscountFromStripeCoupon(stripeCoupon);
+      return { couponId, ...discount };
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message.includes("not valid") ||
+        error.message.includes("redemption limit") ||
+        error.message.includes("minimum order") ||
+        error.message.includes("not active"))
+    ) {
+      throw error;
+    }
+    // Otherwise fall through to the direct coupon lookup.
+  }
+
+  const normalizedCode = normalizeStripeCouponCode(trimmed);
+  if (!normalizedCode) {
+    throw new Error("Please enter a promo code.");
+  }
+  let stripeCoupon: any;
+  try {
+    stripeCoupon = await stripeApiCall(
+      `coupons/${encodeURIComponent(normalizedCode)}`,
+      { method: "GET" },
+    );
+  } catch {
+    throw new Error("This promo code is not valid or has expired.");
+  }
+  assertStripeCouponRedeemable(stripeCoupon);
+  const discount = getDiscountFromStripeCoupon(stripeCoupon);
+  return { couponId: stripeCoupon.id ?? normalizedCode, ...discount };
+}
+
+function computeCouponDiscountAmount(
+  subtotal: number,
+  discountType: "percent" | "amount",
+  discountValue: number,
+): number {
+  if (discountType === "percent") {
+    return Math.round(subtotal * (discountValue / 100) * 100) / 100;
+  }
+  return Math.min(discountValue, subtotal);
+}
+
+// Public validation used by the booking checkout UI to preview a promo code.
+export const validateBookingPromoCode = action({
+  args: {
+    code: v.string(),
+    orderTotal: v.optional(v.number()),
+  },
+  returns: v.object({
+    code: v.string(),
+    discountType: v.union(v.literal("percent"), v.literal("amount")),
+    discountValue: v.number(),
+    discountAmount: v.number(),
+  }),
+  handler: async (_ctx, args) => {
+    const resolved = await resolveStripeCouponForCode(
+      args.code,
+      typeof args.orderTotal === "number" && args.orderTotal > 0
+        ? args.orderTotal
+        : undefined,
+    );
+    const base =
+      typeof args.orderTotal === "number" && args.orderTotal > 0
+        ? args.orderTotal
+        : 0;
+    return {
+      code: resolved.couponId,
+      discountType: resolved.discountType,
+      discountValue: resolved.discountValue,
+      discountAmount: computeCouponDiscountAmount(
+        base,
+        resolved.discountType,
+        resolved.discountValue,
+      ),
+    };
   },
 });
 
@@ -2492,6 +2657,7 @@ async function createCheckoutSessionForDraft(
   ctx: any,
   draft: Doc<"bookingDrafts">,
   origin: string,
+  couponCodeInput?: string,
 ): Promise<BookingCheckoutResult> {
   if (draft.status === "converted") {
     throw new Error("This booking has already been completed.");
@@ -2531,6 +2697,30 @@ async function createCheckoutSessionForDraft(
 
   if (draft.stripeCheckoutSessionId) {
     await expireStripeCheckoutSessionIfPossible(draft.stripeCheckoutSessionId);
+  }
+
+  // Resolve the promo code (explicit input wins; empty string clears; when the
+  // arg is omitted, fall back to whatever is already stored on the draft).
+  const rawCouponCode =
+    couponCodeInput !== undefined ? couponCodeInput : draft.couponCode;
+  let resolvedCoupon: ResolvedStripeCoupon | null = null;
+  if (rawCouponCode && rawCouponCode.trim()) {
+    resolvedCoupon = await resolveStripeCouponForCode(
+      rawCouponCode,
+      draft.totalPrice,
+    );
+  }
+  if (
+    resolvedCoupon?.couponId !== draft.couponCode ||
+    resolvedCoupon?.discountType !== draft.couponDiscountType ||
+    resolvedCoupon?.discountValue !== draft.couponDiscountValue
+  ) {
+    await ctx.runMutation(internal.bookingDrafts.setCouponInternal, {
+      draftId: draft._id,
+      couponCode: resolvedCoupon?.couponId,
+      couponDiscountType: resolvedCoupon?.discountType,
+      couponDiscountValue: resolvedCoupon?.discountValue,
+    });
   }
 
   const { stripeCustomerId } = await ensureStripeCustomerForBookingDraft(ctx, draft);
@@ -2598,6 +2788,9 @@ async function createCheckoutSessionForDraft(
       `Full Service Payment (${vehicleCount} vehicle${vehicleCount > 1 ? "s" : ""})`,
     );
     sessionData.append("line_items[0][quantity]", "1");
+    if (resolvedCoupon) {
+      sessionData.append("discounts[0][coupon]", resolvedCoupon.couponId);
+    }
 
     const session = await stripeApiCall("checkout/sessions", {
       method: "POST",
@@ -2695,6 +2888,7 @@ export const createBookingCheckout = action({
   args: {
     draftId: v.id("bookingDrafts"),
     origin: v.string(),
+    couponCode: v.optional(v.string()),
   },
   returns: v.object({
     sessionId: v.string(),
@@ -2717,7 +2911,12 @@ export const createBookingCheckout = action({
       throw new Error("Booking draft not found");
     }
 
-    return await createCheckoutSessionForDraft(ctx, draft, args.origin);
+    return await createCheckoutSessionForDraft(
+      ctx,
+      draft,
+      args.origin,
+      args.couponCode,
+    );
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -428,6 +428,11 @@ const schema = defineSchema({
       v.literal("full"),
       v.literal("in_person"),
     ),
+    couponCode: v.optional(v.string()),
+    couponDiscountType: v.optional(
+      v.union(v.literal("percent"), v.literal("amount")),
+    ),
+    couponDiscountValue: v.optional(v.number()),
     priceSnapshot: v.array(
       v.object({
         itemType: v.optional(


### PR DESCRIPTION
## Summary

Fixes appointment detail pricing so services display the same vehicle-type-specific prices used by invoice creation.

## Implementation Notes

- Updated appointment detail queries to calculate service display prices through the vehicle type pricing matrix when a vehicle type is present.
- Updated admin edit-mode service previews to use the shared vehicle-aware pricing helper.
- Added regression coverage for a Car vehicle whose legacy size is still medium, matching the reported Car-vs-SUV display mismatch.

## Testing Notes

- `./node_modules/.bin/vitest run convex/appointments.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint --no-warn-ignored components/admin/appointment-detail-client.tsx convex/appointments.ts convex/appointments.test.ts`
- Started dev server with `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm dev`; Convex generated/synced successfully and no generated tracked files changed.

Closes #108
