### PR TITLE
feat: shorten invoice due dates and update express detail copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the River City Mobile Detailing project are documented in
 
 ---
 
+## [v1.0.6] - 2026-07-18
+### Changed
+- **Invoice Due Dates**: Shortened default remaining-balance invoice due dates from 30 days to 3 days for booked, admin-created, supplemental, and legacy Stripe invoice creation flows.
+- **Service Copy**: Renamed the landing page "Quick Clean" service label to "Express Detail".
+
+---
+
 ## [v1.0.5] - 2026-07-18
 ### Added
 - **Booking Checkout Promo Codes**: Added a promo code input to the booking checkout order summary with live red/green validation feedback. Codes resolve against Stripe promotion codes first, then coupon IDs, enforcing usage rules (active status, expiration, redemption caps, minimum order value). Full-payment checkouts apply the coupon via Stripe `discounts`; deposit bookings apply the discount to the remaining balance invoice.

--- a/components/home/footer.tsx
+++ b/components/home/footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
   ];
 
   const services = [
-    "Quick Clean",
+    "Express Detail",
     "Full Detail",
     "Paint Correction",
     "Ceramic Coating",

--- a/components/home/services.tsx
+++ b/components/home/services.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 const services = [
   {
     icon: Zap,
-    title: "Quick Clean",
+    title: "Express Detail",
     description:
       "Full exterior wash, interior vacuum, and quick wax for a fast refresh.",
     features: [

--- a/convex/appointments.test.ts
+++ b/convex/appointments.test.ts
@@ -453,6 +453,7 @@ describe("appointments", () => {
       appointmentId,
       userId,
       status: "draft",
+      dueDate: "2024-12-05",
       subtotal: 25,
       total: 25,
     });

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -21,6 +21,11 @@ import {
   normalizeServiceType,
   type VehicleSize,
 } from "./lib/pricing";
+import {
+  getInvoiceDueDateFromDate,
+  getInvoiceDueDateFromDateKey,
+  REMAINING_BALANCE_DUE_DAYS,
+} from "./lib/invoices";
 import { r2 } from "./r2";
 
 interface StripeInvoiceVehicleInput {
@@ -925,9 +930,7 @@ export const create = mutation({
     const invoiceNumber: string = `INV-${String(invoiceCount + 1).padStart(4, "0")}`;
 
     // Create invoice date
-    const appointmentDate = new Date(`${scheduledDateKey}T00:00:00.000Z`);
-    const dueDate = new Date(appointmentDate);
-    dueDate.setDate(dueDate.getDate() + 30);
+    const dueDate = getInvoiceDueDateFromDateKey(scheduledDateKey);
 
     // Create invoice in Convex immediately (don't create Stripe invoice yet - wait for deposit)
     const invoiceId: Id<"invoices"> = await ctx.db.insert("invoices", {
@@ -939,7 +942,7 @@ export const create = mutation({
       tax,
       total,
       status: "draft", // Start as draft, will be sent after deposit is paid
-      dueDate: dueDate.toISOString().split("T")[0],
+      dueDate,
       notes: `Invoice for appointment on ${scheduledDateKey}`,
       depositAmount,
       depositPaid: false,
@@ -1324,8 +1327,7 @@ export const applyWorkAdjustment = mutation({
           await ctx.runQuery(internal.invoices.getCountInternal, {})
         ).count;
         const invoiceNumber = `INV-${String(invoiceCount + 1).padStart(4, "0")}`;
-        const dueDate = new Date();
-        dueDate.setDate(dueDate.getDate() + 30);
+        const dueDate = getInvoiceDueDateFromDate(new Date());
         supplementalInvoiceId = await ctx.db.insert("invoices", {
           appointmentId: args.appointmentId,
           userId: appointment.userId,
@@ -1342,7 +1344,7 @@ export const applyWorkAdjustment = mutation({
           tax: 0,
           total: priceDelta,
           status: "draft",
-          dueDate: dueDate.toISOString().split("T")[0],
+          dueDate,
           notes: `Supplemental invoice for ${invoice.invoiceNumber}: ${reason}`,
           depositAmount: 0,
           depositPaid: true,
@@ -2165,9 +2167,7 @@ export const createStripeInvoice = action({
     }
 
     // Create the invoice
-    const appointmentDate = new Date(args.scheduledDate);
-    const dueDate = new Date(appointmentDate);
-    dueDate.setDate(dueDate.getDate() + 30);
+    const dueDate = getInvoiceDueDateFromDateKey(args.scheduledDate);
 
     const invoiceResponse = await fetch("https://api.stripe.com/v1/invoices", {
       method: "POST",
@@ -2178,7 +2178,7 @@ export const createStripeInvoice = action({
       body: new URLSearchParams({
         customer: stripeCustomerId!,
         collection_method: "send_invoice",
-        days_until_due: "30",
+        days_until_due: String(REMAINING_BALANCE_DUE_DAYS),
         auto_advance: "true",
         description: `Mobile detailing service - ${args.scheduledDate}`,
       }),
@@ -2260,7 +2260,7 @@ export const createStripeInvoice = action({
       tax,
       total,
       status: "sent",
-      dueDate: dueDate.toISOString().split("T")[0],
+      dueDate,
       stripeInvoiceId: sentInvoice.id,
       stripeInvoiceUrl: sentInvoice.hosted_invoice_url,
       notes: `Invoice for appointment on ${args.scheduledDate}`,
@@ -2367,9 +2367,7 @@ export const createStripeInvoiceInternal = internalAction({
     }
 
     // Create Stripe invoice
-    const appointmentDate = new Date(args.scheduledDate);
-    const dueDate = new Date(appointmentDate);
-    dueDate.setDate(dueDate.getDate() + 30);
+    const dueDate = getInvoiceDueDateFromDateKey(args.scheduledDate);
 
     const invoiceResponse = await fetch("https://api.stripe.com/v1/invoices", {
       method: "POST",
@@ -2380,7 +2378,7 @@ export const createStripeInvoiceInternal = internalAction({
       body: new URLSearchParams({
         customer: stripeCustomerId,
         collection_method: "send_invoice",
-        days_until_due: "30",
+        days_until_due: String(REMAINING_BALANCE_DUE_DAYS),
         auto_advance: "true",
         description: `Mobile detailing service - ${args.scheduledDate}`,
         metadata: JSON.stringify({
@@ -2459,7 +2457,7 @@ export const createStripeInvoiceInternal = internalAction({
       tax,
       total,
       status: "sent",
-      dueDate: dueDate.toISOString().split("T")[0],
+      dueDate,
       stripeInvoiceId: sentInvoice.id,
       stripeInvoiceUrl: sentInvoice.hosted_invoice_url,
       notes: `Invoice for appointment on ${args.scheduledDate}`,

--- a/convex/bookingDrafts.ts
+++ b/convex/bookingDrafts.ts
@@ -30,6 +30,7 @@ import {
   getEffectiveServicePrice,
   type VehicleSize,
 } from "./lib/pricing";
+import { getInvoiceDueDateFromDateKey } from "./lib/invoices";
 import { assertRateLimit, contactRateLimitKey } from "./rateLimiter";
 
 const HOLD_DURATION_MS = 15 * 60 * 1000;
@@ -1314,8 +1315,7 @@ export const convertSuccessfulCheckout = internalMutation({
       {},
     );
     const invoiceNumber: string = `INV-${String(invoiceCountResult.count + 1).padStart(4, "0")}`;
-    const dueDate = new Date(`${draft.scheduledDate}T00:00:00.000Z`);
-    dueDate.setUTCDate(dueDate.getUTCDate() + 30);
+    const dueDate = getInvoiceDueDateFromDateKey(draft.scheduledDate);
     const today = new Date().toISOString().split("T")[0];
     const isFullPayment = draft.paymentOption === "full";
 
@@ -1332,7 +1332,7 @@ export const convertSuccessfulCheckout = internalMutation({
       tax: 0,
       total: discountedTotal,
       status: isFullPayment ? "paid" : "draft",
-      dueDate: dueDate.toISOString().split("T")[0],
+      dueDate,
       paidDate: isFullPayment ? today : undefined,
       notes: `Invoice for appointment on ${draft.scheduledDate}`,
       depositAmount: isFullPayment ? discountedTotal : draft.depositAmount,

--- a/convex/lib/invoices.ts
+++ b/convex/lib/invoices.ts
@@ -1,0 +1,19 @@
+export const REMAINING_BALANCE_DUE_DAYS = 3;
+
+export function getInvoiceDueDateFromDateKey(
+  dateKey: string,
+  daysUntilDue = REMAINING_BALANCE_DUE_DAYS,
+): string {
+  const dueDate = new Date(`${dateKey}T00:00:00.000Z`);
+  dueDate.setUTCDate(dueDate.getUTCDate() + daysUntilDue);
+  return dueDate.toISOString().split("T")[0];
+}
+
+export function getInvoiceDueDateFromDate(
+  date: Date,
+  daysUntilDue = REMAINING_BALANCE_DUE_DAYS,
+): string {
+  const dueDate = new Date(date);
+  dueDate.setUTCDate(dueDate.getUTCDate() + daysUntilDue);
+  return dueDate.toISOString().split("T")[0];
+}

--- a/convex/payments.test.ts
+++ b/convex/payments.test.ts
@@ -3308,5 +3308,6 @@ describe("payments", () => {
     expect(invoice?.total).toBe(80);
     expect(invoice?.depositAmount).toBe(50);
     expect(invoice?.remainingBalance).toBe(30);
+    expect(invoice?.dueDate).toBe("2024-12-07");
   });
 });

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1157,5 +1157,6 @@ describe("users", () => {
         }),
       ]),
     );
+    expect(invoice?.dueDate).toBe("2024-12-05");
   });
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -18,6 +18,10 @@ import {
   type VehicleSize,
 } from "./lib/pricing";
 import {
+  getInvoiceDueDateFromDateKey,
+  REMAINING_BALANCE_DUE_DAYS,
+} from "./lib/invoices";
+import {
   DEFAULT_USER_NOTIFICATION_PREFERENCES,
   normalizeUserNotificationPreferences,
   userNotificationPreferencesValidator,
@@ -1658,9 +1662,7 @@ export const createUserWithAppointment = mutation({
     const invoiceNumber: string = `INV-${String(invoiceCount + 1).padStart(4, "0")}`;
 
     // Create invoice date
-    const appointmentDate = new Date(`${scheduledDateKey}T00:00:00.000Z`);
-    const dueDate = new Date(appointmentDate);
-    dueDate.setDate(dueDate.getDate() + 30);
+    const dueDate = getInvoiceDueDateFromDateKey(scheduledDateKey);
 
     // Adjust invoice fields based on payment option
     const paymentOption = args.paymentOption ?? "deposit";
@@ -1688,7 +1690,7 @@ export const createUserWithAppointment = mutation({
       tax,
       total,
       status: "draft", // Start as draft, will be sent after deposit is paid
-      dueDate: dueDate.toISOString().split("T")[0],
+      dueDate,
       notes: `Invoice for appointment on ${scheduledDateKey}`,
       depositAmount: invoiceDepositAmount,
       depositPaid: invoiceDepositPaid,
@@ -2040,9 +2042,7 @@ export const createUserAppointmentInvoice = action({
     }
 
     // Create the invoice
-    const appointmentDate = new Date(args.scheduledDate);
-    const dueDate = new Date(appointmentDate);
-    dueDate.setDate(dueDate.getDate() + 30);
+    const dueDate = getInvoiceDueDateFromDateKey(args.scheduledDate);
 
     const invoiceResponse: Response = await fetch(
       "https://api.stripe.com/v1/invoices",
@@ -2055,7 +2055,7 @@ export const createUserAppointmentInvoice = action({
         body: new URLSearchParams({
           customer: stripeCustomerId!,
           collection_method: "send_invoice",
-          days_until_due: "30",
+          days_until_due: String(REMAINING_BALANCE_DUE_DAYS),
           auto_advance: "true",
           description: `Mobile detailing service - ${args.scheduledDate}`,
         }),
@@ -2134,7 +2134,7 @@ export const createUserAppointmentInvoice = action({
       tax,
       total,
       status: "draft", // Start as draft, will be sent after deposit is paid
-      dueDate: dueDate.toISOString().split("T")[0],
+      dueDate,
       stripeInvoiceId: sentInvoice.id,
       stripeInvoiceUrl: sentInvoice.hosted_invoice_url,
       notes: `Invoice for appointment on ${args.scheduledDate}`,


### PR DESCRIPTION
## Summary

Set default remaining-balance invoice due dates to 3 days instead of 30 days for the detailing payment flow.

Also rename the landing page service card label from Quick Clean to Express Detail.

## Implementation Notes

- Added a shared Convex invoice due-date helper with a 3-day default.
- Updated customer booking conversion, admin-created appointments, supplemental invoices, and legacy Stripe invoice fallbacks to use 3 days.
- Kept Stripe behavior aligned with collection method rules: active remaining-balance invoices still send exact due_date for send_invoice; legacy days_until_due fallbacks now use 3.
- Added regression assertions for admin-created and booking-converted invoice due dates.
- Updated CHANGELOG.md for v1.0.6.

## Testing Notes

- pnpm lint
- pnpm test:once convex/appointments.test.ts convex/users.test.ts convex/payments.test.ts
- pnpm test:once
- ./node_modules/.bin/tsc --noEmit
- pnpm check is not defined in this package
- pnpm typecheck is not defined in this package; used direct tsc instead

Closes #112